### PR TITLE
Bug fix: Button markers not hiding when character looks away from button

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Character/MyCharacter.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Character/MyCharacter.cs
@@ -1832,7 +1832,7 @@ namespace Sandbox.Game.Entities.Character
                     interactive = block.GetInteractiveObject(h.HkHitInfo.GetShapeKey(0));
                 }
 
-                if (UseObject != null && UseObject != interactive)
+                if (UseObject != null && interactive != null && UseObject != interactive)
                 {
                     UseObject.OnSelectionLost();
                 }
@@ -1858,6 +1858,8 @@ namespace Sandbox.Game.Entities.Character
 
             if (!hasInteractive)
             {
+                if (UseObject != null)
+                    UseObject.OnSelectionLost();
                 UseObject = null;
             }
 


### PR DESCRIPTION
Bug fix for button markers not hiding when character looks away from button and raytrace does not hit anything.