### PR TITLE
Mass property for IMyCubeBlock and IMySlimBlock

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/IMyCubeBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/IMyCubeBlock.cs
@@ -116,6 +116,11 @@ namespace Sandbox.ModAPI
         /// Maximum coordinates of grid cells occupied by this block
         /// </summary>
         VRageMath.Vector3I Max { get; }
+        
+        /// <summary>
+        /// Block mass
+        /// </summary>
+        float Mass { get; }
         /// <summary>
         /// Minimum coordinates of grid cells occupied by this block
         /// </summary>

--- a/Sources/Sandbox.Common/ModAPI/IMySlimBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/IMySlimBlock.cs
@@ -36,6 +36,7 @@ namespace Sandbox.ModAPI
         bool IsFullyDismounted { get; }
         float MaxDeformation { get; }
         float MaxIntegrity { get; }
+        float Mass { get; }
         //void MoveFirstItemToConstructionStockpile(Sandbox.Game.MyInventory fromInventory);
         //void MoveItemsFromConstructionStockpile(Sandbox.Game.MyInventory toInventory, Sandbox.Common.ObjectBuilders.MyItemFlags flags = MyItemFlags.None);
         //void MoveItemsToConstructionStockpile(Sandbox.Game.MyInventory fromInventory);

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyCubeBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyCubeBlock.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 namespace Sandbox.ModAPI.Ingame
 {
+    /// <summary>
+    /// Basic cube interface
+    /// </summary>
     public interface IMyCubeBlock : IMyEntity
     {
         Sandbox.Common.ObjectBuilders.Definitions.SerializableDefinitionId BlockDefinition { get; }
@@ -17,6 +20,11 @@ namespace Sandbox.ModAPI.Ingame
         bool IsFunctional { get; }
         bool IsWorking { get; }
         VRageMath.Vector3I Max { get; }
+
+        /// <summary>
+        /// Block mass
+        /// </summary>
+        float Mass { get; }
         VRageMath.Vector3I Min { get; }
         int NumberInGrid { get; }
         VRageMath.MyBlockOrientation Orientation { get; }

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMySlimBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMySlimBlock.cs
@@ -2,6 +2,9 @@
 using VRageMath;
 namespace Sandbox.ModAPI.Ingame
 {
+    /// <summary>
+    /// basic block interface
+    /// </summary>
     public interface IMySlimBlock
     {
         float AccumulatedDamage { get; }
@@ -17,6 +20,10 @@ namespace Sandbox.ModAPI.Ingame
         bool IsFullyDismounted { get; }
         float MaxDeformation { get; }
         float MaxIntegrity { get; }
+        /// <summary>
+        /// Block mass
+        /// </summary>
+        float Mass { get; }
         bool ShowParts { get; }
         bool StockpileAllocated { get; }
         bool StockpileEmpty { get; }

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBlock.cs
@@ -115,6 +115,7 @@ namespace Sandbox.Game.Entities
 
         public MyCubeBlockDefinition BlockDefinition { get { return SlimBlock.BlockDefinition; } }
         public Vector3I Min { get { return SlimBlock.Min; } }
+        public float Mass { get { return SlimBlock.GetMass(); } }
         public Vector3I Max { get { return SlimBlock.Max; } }
         public MyBlockOrientation Orientation { get { return SlimBlock.Orientation; } }
         public Vector3I Position { get { return SlimBlock.Position; } }

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBlock.cs
@@ -115,7 +115,6 @@ namespace Sandbox.Game.Entities
 
         public MyCubeBlockDefinition BlockDefinition { get { return SlimBlock.BlockDefinition; } }
         public Vector3I Min { get { return SlimBlock.Min; } }
-        public float Mass { get { return SlimBlock.GetMass(); } }
         public Vector3I Max { get { return SlimBlock.Max; } }
         public MyBlockOrientation Orientation { get { return SlimBlock.Orientation; } }
         public Vector3I Position { get { return SlimBlock.Position; } }

--- a/Sources/Sandbox.Game/ModAPI/Blocks/MyCubeBlock_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/Blocks/MyCubeBlock_ModAPI.cs
@@ -124,6 +124,11 @@ namespace Sandbox.Game.Entities
             get { return Max; }
         }
 
+        float IMyCubeBlock.Mass
+        {
+            get { return Mass; }
+        }
+
         VRageMath.Vector3I IMyCubeBlock.Min
         {
             get { return Min; }

--- a/Sources/Sandbox.Game/ModAPI/Blocks/MyCubeBlock_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/Blocks/MyCubeBlock_ModAPI.cs
@@ -126,9 +126,13 @@ namespace Sandbox.Game.Entities
 
         float IMyCubeBlock.Mass
         {
-            get { return Mass; }
+            get { return GetMass(); }
         }
 
+        float ModAPI.Ingame.IMyCubeBlock.Mass
+        {
+            get { return GetMass(); }
+        }
         VRageMath.Vector3I IMyCubeBlock.Min
         {
             get { return Min; }

--- a/Sources/Sandbox.Game/ModAPI/Blocks/MySlimBlock_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/Blocks/MySlimBlock_ModAPI.cs
@@ -138,6 +138,10 @@ namespace Sandbox.Game.Entities.Cube
             get { return MaxIntegrity; }
         }
 
+        float IMySlimBlock.Mass
+        {
+            get { return GetMass();  }
+        }
         void IMySlimBlock.RemoveNeighbours()
         {
             RemoveNeighbours();
@@ -236,6 +240,11 @@ namespace Sandbox.Game.Entities.Cube
         float ModAPI.Ingame.IMySlimBlock.MaxIntegrity
         {
             get { return MaxIntegrity; }
+        }
+
+        float ModAPI.Ingame.IMySlimBlock.Mass
+        {
+            get { return GetMass(); }
         }
 
         bool ModAPI.Ingame.IMySlimBlock.ShowParts


### PR DESCRIPTION
Property to retrieve block mass in modapi and ingame scripts
This property retrieves block mass from block definition (eg. not virtual mass, like spaceball hass, but blueprint one)