### PR TITLE
Fix to reported bug - projectors duplicate ingots.

### DIFF
--- a/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_ProductionBlock.cs
+++ b/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_ProductionBlock.cs
@@ -58,6 +58,8 @@ namespace Sandbox.Common.ObjectBuilders
             base.SetupForProjector();
             if (Inventory != null)
                 Inventory.Clear();
+			if (OutputInventory != null)
+				OutputInventory.Clear();
         }
 
     }

--- a/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_ProductionBlock.cs
+++ b/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_ProductionBlock.cs
@@ -58,8 +58,8 @@ namespace Sandbox.Common.ObjectBuilders
             base.SetupForProjector();
             if (Inventory != null)
                 Inventory.Clear();
-			if (OutputInventory != null)
-				OutputInventory.Clear();
+            if (OutputInventory != null)
+                OutputInventory.Clear();
         }
 
     }


### PR DESCRIPTION
This addresses the known bug (reported on the forums) where building a refinery via a projector causes duplication of ingots at no cost.  The output inventory of production blocks was not being cleared.