### PR TITLE
Interior Door/Airtight Hangar Door Fixes

### DIFF
--- a/Sources/Sandbox.Common/ObjectBuilders/Definitions/MyObjectBuilder_DoorDefinition.cs
+++ b/Sources/Sandbox.Common/ObjectBuilders/Definitions/MyObjectBuilder_DoorDefinition.cs
@@ -19,5 +19,8 @@ namespace Sandbox.Common.ObjectBuilders.Definitions
 
         [ProtoMember(3)]
         public string CloseSound;
+
+        [ProtoMember(4)]
+        public float OpeningSpeed;
     }
 }

--- a/Sources/Sandbox.Game/Definitions/MyDoorDefinition.cs
+++ b/Sources/Sandbox.Game/Definitions/MyDoorDefinition.cs
@@ -13,6 +13,7 @@ namespace Sandbox.Definitions
         public float MaxOpen;
         public string OpenSound;
         public string CloseSound;
+        public float OpeningSpeed;
 
         protected override void Init(MyObjectBuilder_DefinitionBase builder)
         {
@@ -23,6 +24,7 @@ namespace Sandbox.Definitions
             MaxOpen = doorBuilder.MaxOpen;
             OpenSound = doorBuilder.OpenSound;
             CloseSound = doorBuilder.CloseSound;
+            OpeningSpeed = doorBuilder.OpeningSpeed;
         }
     }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyAirtightDoorGeneric.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyAirtightDoorGeneric.cs
@@ -217,6 +217,7 @@ namespace Sandbox.Game.Entities.Blocks
                 //END OF MOVEMENT
                 if (m_soundEmitter.IsPlaying && m_soundEmitter.Loop)
                     m_soundEmitter.StopSound(false);
+
                 m_currSpeed = 0;
                 PowerReceiver.Update();
                 RaisePropertiesChanged();
@@ -231,6 +232,11 @@ namespace Sandbox.Game.Entities.Blocks
             {
                 StartSound(m_sound);
             }
+            else
+            {
+                m_soundEmitter.StopSound(false);
+            }
+
             base.UpdateBeforeSimulation();
             UpdateCurrentOpening();
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyDoor.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyDoor.cs
@@ -31,12 +31,12 @@ namespace Sandbox.Game.Entities
     {
         private const float CLOSED_DISSASEMBLE_RATIO = 3.3f;
 
-        private const float SLIDINGSPEED = 1.0f;
         private MySoundPair m_openSound;
         private MySoundPair m_closeSound;
 
         private float m_currOpening;
-        private float m_slidingSpeed;
+        protected float m_slidingSpeed = 1f;
+        protected float m_currSpeed = 0;
         private int m_lastUpdateTime;
 
         private MyEntitySubpart m_leftSubpart = null;
@@ -70,7 +70,7 @@ namespace Sandbox.Game.Entities
         {
             m_open = false;
             m_currOpening = 0f;
-            m_slidingSpeed = 0f;
+            m_currSpeed = 0f;
             SyncObject = new MySyncDoor(this);
         }
 
@@ -147,6 +147,7 @@ namespace Sandbox.Game.Entities
                 MaxOpen = doorDefinition.MaxOpen;
                 m_openSound = new MySoundPair(doorDefinition.OpenSound);
                 m_closeSound = new MySoundPair(doorDefinition.CloseSound);
+                m_slidingSpeed = (doorDefinition.OpeningSpeed <= 0f) ? 1f : doorDefinition.OpeningSpeed;
             }
             else
             {
@@ -231,15 +232,16 @@ namespace Sandbox.Game.Entities
             ob.Opening = m_currOpening;
             ob.OpenSound = m_openSound.ToString();
             ob.CloseSound = m_closeSound.ToString();
+            
             return ob;
         }
 
         private void OnStateChange()
         {
             if (m_open)
-                m_slidingSpeed = SLIDINGSPEED;
+                m_currSpeed = m_slidingSpeed;
             else
-                m_slidingSpeed = -SLIDINGSPEED;
+                m_currSpeed = -m_slidingSpeed;
 
             NeedsUpdate = MyEntityUpdateEnum.EACH_FRAME | MyEntityUpdateEnum.EACH_100TH_FRAME;
             m_lastUpdateTime = MySandboxGame.TotalGamePlayTimeInMilliseconds;
@@ -301,7 +303,7 @@ namespace Sandbox.Game.Entities
             if (Enabled && PowerReceiver.IsPowered)
             {
                 float timeDelta = (MySandboxGame.TotalGamePlayTimeInMilliseconds - m_lastUpdateTime) / 1000f;
-                float deltaPos = m_slidingSpeed * timeDelta;
+                float deltaPos = m_currSpeed * timeDelta;
                 m_currOpening = MathHelper.Clamp(m_currOpening + deltaPos, 0f, MaxOpen);
             }
         }

--- a/Sources/Sandbox.Game/Game/GameSystems/MyGridOxygenSystem.cs
+++ b/Sources/Sandbox.Game/Game/GameSystems/MyGridOxygenSystem.cs
@@ -1175,7 +1175,7 @@ namespace Sandbox.Game.GameSystems
             if (block.FatBlock != null)
             {
                 var door = block.FatBlock as MyDoor;
-                if (door != null && !door.Open)
+                if (door != null && door.IsFullyClosed)
                 {
                     foreach (var mountPoint in block.BlockDefinition.MountPoints)
                     {


### PR DESCRIPTION
-Fixed Airtight Hangar looping Sound Bug
-Fixed Interior Doors being Airtight when not fully closed
-Added OpeningSpeed Parameter for Interior Door in Block Definition
example: `<OpeningSpeed>0.2</OpeningSpeed>`
defaults to 1 if not defined