### PR TITLE
Expose Power getters of Reactor, Solar and Battery for ingame scripts

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyBatteryBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyBatteryBlock.cs
@@ -8,5 +8,9 @@ namespace Sandbox.ModAPI.Ingame
     public interface IMyBatteryBlock : IMyFunctionalBlock
     {
         bool HasCapacityRemaining { get; }
+        float CurrentPowerOutput { get; }
+        float MaxPowerOutput { get; }
+        float CurrentStoredPower { get; }
+        float MaxStoredPower { get; }
     }
 }

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyReactor.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyReactor.cs
@@ -8,5 +8,7 @@ namespace Sandbox.ModAPI.Ingame
     public interface IMyReactor : IMyFunctionalBlock
     {
         bool UseConveyorSystem { get; }
+        float CurrentPowerOutput { get; }
+        float MaxPowerOutput { get; }
     }
 }

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMySolarPanel.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMySolarPanel.cs
@@ -7,5 +7,7 @@ namespace Sandbox.ModAPI.Ingame
 {
     public interface IMySolarPanel : IMyTerminalBlock
     {
+        float CurrentPowerOutput { get; }
+        float MaxPowerOutput { get; }
     }
 }


### PR DESCRIPTION
Expose CurrentPowerOutput and MaxPowerOutput of Reactor, Solar Panel and Battery for ingame scripts. Also exposes CurrentPowerStored and MaxPowerStored for Battery.