### PR TITLE
Find toolbar group actions by type instead of Definition Id

### DIFF
--- a/Sources/Sandbox.Game/Game/Screens/Helpers/MyToolbarItemTerminalGroup.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Helpers/MyToolbarItemTerminalGroup.cs
@@ -18,7 +18,7 @@ namespace Sandbox.Game.Screens.Helpers
     [MyToolbarItemDescriptor(typeof(MyObjectBuilder_ToolbarItemTerminalGroup))]
     class MyToolbarItemTerminalGroup : MyToolbarItemActions
     {
-        private static HashSet<MyDefinitionId> tmpBlockDefinitions = new HashSet<MyDefinitionId>();
+        private static HashSet<Type> tmpBlockTypes = new HashSet<Type>();
         private static List<MyTerminalBlock> m_tmpBlocks = new List<MyTerminalBlock>();
         private static StringBuilder m_tmpStringBuilder = new StringBuilder();
 
@@ -52,15 +52,15 @@ namespace Sandbox.Game.Screens.Helpers
                 foreach (var block in blocks)
                 {
                     allFunctional &= block is MyFunctionalBlock;
-                    tmpBlockDefinitions.Add(block.BlockDefinition.Id);
+                    tmpBlockTypes.Add(block.GetType());
                 }
 
-                if (tmpBlockDefinitions.Count == 1)
+                if (tmpBlockTypes.Count == 1)
                 {
                     genericType = false;
                     return GetValidActions(blocks.ItemAt(0).GetType());
                 }
-                else if (tmpBlockDefinitions.Count == 0 || !allFunctional)
+                else if (tmpBlockTypes.Count == 0 || !allFunctional)
                 {
                     genericType = true;
                     return ListReader<ITerminalAction>.Empty;
@@ -73,7 +73,7 @@ namespace Sandbox.Game.Screens.Helpers
             }
             finally
             {
-                tmpBlockDefinitions.Clear();
+                tmpBlockTypes.Clear();
             }
         }
 


### PR DESCRIPTION
Find toolbar group actions by type instead of Definition Id to support toolbar actions for group of different variations of same block type.

For example group of different modded doors or different sizes of modded Hangar Door do not currently allow toolbar open/close action and only provide Functional Block actions - this fixes it.