### PR TITLE
Update Projector text when its state changes

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyProjector.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyProjector.cs
@@ -451,6 +451,7 @@ namespace Sandbox.Game.Entities.Blocks
             if (m_clipboard.PreviewGrids.Count != 0)
                 ProjectedGrid.Projector = this;
             m_shouldUpdateProjection = true;
+            m_shouldUpdateTexts = true;
 
             SetRotation(m_projectionRotation);
 
@@ -521,6 +522,8 @@ namespace Sandbox.Game.Entities.Blocks
             IsWorkingChanged += MyProjector_IsWorkingChanged;
 
             PowerReceiver.Update();
+            m_statsDirty = true;
+            UpdateText();
             
             SyncObject = new MySyncProjector(this);
 
@@ -700,12 +703,14 @@ namespace Sandbox.Game.Entities.Blocks
                         }
                     }
                 }
+                m_shouldUpdateTexts = true;
             }
         }
 
         void previewGrid_OnBlockRemoved(MySlimBlock obj)
         {
             m_shouldUpdateProjection = true;
+            m_shouldUpdateTexts = true;
         }
 
         //Stats
@@ -846,6 +851,8 @@ namespace Sandbox.Game.Entities.Blocks
             }
 
             UpdateEmissivity();
+            m_statsDirty = true;
+            UpdateText();
 
             //We call this to disable the controls
             RaisePropertiesChanged();


### PR DESCRIPTION
Fixes issue where projector doesn't have any text in terminal.
Updates Projector text on init, on projection init & destroy and on block add & remove. 

This is also needed for ingame scripts to be able to reliably read it.