### PR TITLE
Issue #38: Force the upgrade module to refresh its state when the power changes

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyUpgradeModule.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyUpgradeModule.cs
@@ -114,6 +114,7 @@ namespace Sandbox.Game.Entities.Blocks
             if (CubeGrid.GridSystems.PowerDistributor.PowerState != m_oldPowerState)
             {
                 m_oldPowerState = CubeGrid.GridSystems.PowerDistributor.PowerState;
+                m_needsRefresh = true;                      // Force refresh on power change (including initial power-on during world load)
                 UpdateEmissivity();
             }
 


### PR DESCRIPTION
This also happens on world load, which allows upgrade scripts not using MyGameLogicComponent to function.

This should happen infrequently enough to not have any performance impact.