### PR TITLE
Allow modding the Laser Antenna's line-of-sight requirements

### DIFF
--- a/Sources/Sandbox.Common/ObjectBuilders/Definitions/MyObjectBuilder_LaserAntennaDefinition.cs
+++ b/Sources/Sandbox.Common/ObjectBuilders/Definitions/MyObjectBuilder_LaserAntennaDefinition.cs
@@ -21,5 +21,7 @@ namespace Sandbox.Common.ObjectBuilders.Definitions
         public float RotationRate = MathHelper.Pi / 20000.0f;
         [ProtoMember(5)]
         public float MaxRange = 40000;
+        [ProtoMember(6)]
+        public bool RequireLineOfSight = true;
     }
 }

--- a/Sources/Sandbox.Game/Definitions/MyLaserAntennaDefinition.cs
+++ b/Sources/Sandbox.Game/Definitions/MyLaserAntennaDefinition.cs
@@ -17,6 +17,8 @@ namespace Sandbox.Definitions
 
         public float MaxRange;
 
+        public bool RequireLineOfSight;
+
         protected override void Init(MyObjectBuilder_DefinitionBase builder)
         {
             base.Init(builder);
@@ -28,6 +30,7 @@ namespace Sandbox.Definitions
             PowerInputLasing = ob.PowerInputLasing;
             RotationRate=ob.RotationRate;
             MaxRange = ob.MaxRange;
+            RequireLineOfSight = ob.RequireLineOfSight;
         }
     }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
@@ -90,6 +90,8 @@ namespace Sandbox.Game.Entities.Cube
         bool m_IsPermanent = false;
         bool m_OnlyPermanentExists = false;
 
+        public bool m_needLineOfSight = true;
+
         public Vector3D HeadPos{
             get{
                 if (m_base2!=null)
@@ -422,6 +424,7 @@ namespace Sandbox.Game.Entities.Cube
             m_targetCoords = ob.LastTargetPosition;
 
             m_maxRange = BlockDefinition.MaxRange;
+            m_needLineOfSight = BlockDefinition.RequireLineOfSight;
 
             InitializationMatrix = (MatrixD)PositionComp.LocalMatrix;
 
@@ -646,7 +649,7 @@ namespace Sandbox.Game.Entities.Cube
                         || !IsInRange(target)
                         || !m_receiver.CanIUseIt(target.m_broadcaster, this.OwnerId)
                         || !target.m_receiver.CanIUseIt(m_broadcaster, target.OwnerId)
-                        || !LosTest(target.HeadPos)//target will make other half of line in its update
+                        || (m_needLineOfSight && !LosTest(target.HeadPos))//target will make other half of line in its update
                         )
                         sync.ShiftMode(StateEnum.contact_Rec);//other side MIA
                     else

--- a/Sources/SpaceEngineers/Content/Data/CubeBlocks.sbc
+++ b/Sources/SpaceEngineers/Content/Data/CubeBlocks.sbc
@@ -21635,6 +21635,7 @@
       <PowerInputLasing>0.576</PowerInputLasing>
       <RotationRate>0.01</RotationRate>
       <MaxRange>40000</MaxRange>
+      <RequireLineOfSight>true</RequireLineOfSight>
     </Definition>
     <Definition xsi:type="MyObjectBuilder_LaserAntennaDefinition">
       <Id>
@@ -21681,6 +21682,7 @@
       <PowerInputLasing>0.18</PowerInputLasing>
       <RotationRate>0.01</RotationRate>
       <MaxRange>20000</MaxRange>
+      <RequireLineOfSight>true</RequireLineOfSight>
     </Definition>
 
     <Definition xsi:type="MyObjectBuilder_AirtightHangarDoorDefinition">


### PR DESCRIPTION
Added the option for modders to create laser antennas unrestricted by the line-of-sight requirement.