### PR TITLE
Exposed grid displayname

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyCubeGrid.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyCubeGrid.cs
@@ -10,5 +10,6 @@ namespace Sandbox.ModAPI.Ingame
         VRageMath.Vector3I Max { get; }
         VRageMath.Vector3I Min { get; }
         IMySlimBlock GetCubeBlock(VRageMath.Vector3I pos);
+        string DisplayName { get; }
     }
 }


### PR DESCRIPTION
Exposed the grid displayname. Resubmit due to accidentally closing #4.