### PR TITLE
Expose block deconstruction to ModAPI

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/IMySlimBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/IMySlimBlock.cs
@@ -21,6 +21,7 @@ namespace Sandbox.ModAPI
         //void DoDamage(float damage, Sandbox.Game.Weapons.MyDamageType damageType, bool addDirtyParts = true);
         IMyCubeBlock FatBlock { get; }
         void FixBones(float oldDamage, float maxAllowedBoneMovement);
+        void FullyDismount(IMyInventory outputInventory);
         //int GetConstructionStockpileItemAmount(Sandbox.Definitions.MyDefinitionId id);
         Sandbox.Common.ObjectBuilders.MyObjectBuilder_CubeBlock GetCopyObjectBuilder();
         void GetMissingComponents(System.Collections.Generic.Dictionary<string, int> addToDictionary);

--- a/Sources/Sandbox.Common/ModAPI/IMySlimBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/IMySlimBlock.cs
@@ -37,7 +37,7 @@ namespace Sandbox.ModAPI
         float MaxDeformation { get; }
         float MaxIntegrity { get; }
         //void MoveFirstItemToConstructionStockpile(Sandbox.Game.MyInventory fromInventory);
-        //void MoveItemsFromConstructionStockpile(Sandbox.Game.MyInventory toInventory, Sandbox.Common.ObjectBuilders.MyItemFlags flags = MyItemFlags.None);
+        void MoveItemsFromConstructionStockpile(IMyInventory toInventory, Sandbox.Common.ObjectBuilders.MyItemFlags flags = Sandbox.Common.ObjectBuilders.MyItemFlags.None);
         //void MoveItemsToConstructionStockpile(Sandbox.Game.MyInventory fromInventory);
         //void PlayConstructionSound(Sandbox.Game.Entities.MyCubeGrid.MyIntegrityChangeEnum integrityChangeType, bool deconstruction = false);
         void RemoveNeighbours();

--- a/Sources/Sandbox.Game/ModAPI/Blocks/MySlimBlock_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/Blocks/MySlimBlock_ModAPI.cs
@@ -158,6 +158,11 @@ namespace Sandbox.Game.Entities.Cube
             SpawnConstructionStockpile();
         }
 
+        void IMySlimBlock.MoveItemsFromConstructionStockpile(IMyInventory toInventory, Sandbox.Common.ObjectBuilders.MyItemFlags flags)
+        {
+            MoveItemsFromConstructionStockpile(toInventory as MyInventory, flags);
+        }
+
         void IMySlimBlock.SpawnFirstItemInConstructionStockpile()
         {
             SpawnFirstItemInConstructionStockpile();

--- a/Sources/Sandbox.Game/ModAPI/Blocks/MySlimBlock_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/Blocks/MySlimBlock_ModAPI.cs
@@ -78,6 +78,11 @@ namespace Sandbox.Game.Entities.Cube
             FixBones(oldDamage, maxAllowedBoneMovement);
         }
 
+        void IMySlimBlock.FullyDismount(IMyInventory outputInventory)
+        {
+            FullyDismount(outputInventory as MyInventory);
+        }
+
         Common.ObjectBuilders.MyObjectBuilder_CubeBlock IMySlimBlock.GetCopyObjectBuilder()
         {
             return GetCopyObjectBuilder();


### PR DESCRIPTION
As a mod developer, I wanted to restrict player placement of certain types of blocks and remove them when over a certain limit. The logic's easy enough, but spawning the components contained within an existing Cubeblock / moving them into player inventory was not possible.

This PR contains the bare minimum to get done what I wanted to, but I'm happy to help whitelist other functions if needed. I wanted to keep my footprint small because I don't know why this was blacklisted in the first place, and I'm not a very proficient C# coder.

The first commit in this PR whitelists `MySlimBlock.MoveItemsFromConstructionStockpile()` for the ModAPI so that us modders can take items from a ConstructionStockpile and move them into another inventory. 

The second commit adds and whitelists a new helper function `MySlimBlock.FullyDismount()`, which mimics the logic of `DecreaseMountLevel()` in the much simpler case where you want to deconstruct it entirely. 

I was torn about the best way to implement this. `DecreaseMountLevel()` was not yet whitelisted, but in order to use it I'd also have to use the block's `MaxIntegrity`, `DisassembleRatio`, and `IntegrityPointsPerSec` (the latter two aren't whitelisted either) to determine the `gridAmount` to pass through to `DecreaseMountLevel()` that would fully deconstruct the block. So this seemed like a useful helper function, regardless of its use for ModAPI.

I considered deconstructing the logic of `DecreaseMountLevel()` into various methods to decrease repetition between it and `FullyDismount()`, but it seemed like that didn't fit so well with the dev methodology of the rest of the project, and `FullyDismount()` was fortunately a much simpler case of `DecreaseMountLevel()` so it seemed less necessary. Please let me know if I should adjust.

I've tested this in both Dev and Release mode with a mod making use of the whitelisted functions successfully.