### PR TITLE
Improve asteroid generation

### DIFF
--- a/Sources/Sandbox.Game/Engine/Voxels/MyCsgShapeMetaball.cs
+++ b/Sources/Sandbox.Game/Engine/Voxels/MyCsgShapeMetaball.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using VRage.Noise;
+using VRageMath;
+
+namespace Sandbox.Engine.Voxels
+{
+    class MyCsgShapeMetaball : MyCsgShapeBase
+    {
+        private Vector3 m_translation;
+        private Vector3[] m_balls;
+        private float[] m_weights;
+        private float m_radius;
+        private float m_halfDeviation;
+        private float m_deviationFrequency;
+        private float m_detailFrequency;
+
+        private float m_outerRadius;
+        private float m_innerRadius;
+
+        public MyCsgShapeMetaball(Vector3 translation, Vector3[] balls, float[] weights, float radius, float halfDeviation = 0,
+            float deviationFrequency = 0, float detailFrequency = 0)
+        {
+            m_translation = translation;
+            m_balls = balls;
+            m_weights = weights;
+            m_radius = radius;
+            m_halfDeviation = halfDeviation;
+            m_deviationFrequency = deviationFrequency;
+            m_detailFrequency = detailFrequency;
+
+            ComputeDerivedProperties();
+        }
+
+        internal override ContainmentType Contains(ref BoundingBox queryAabb, ref BoundingSphere querySphere, float lodVoxelSize)
+        {
+            for (int i = 0; i < m_balls.Length; i++)
+            {
+                ContainmentType outerContainment;
+                BoundingSphere sphere = new BoundingSphere(m_translation + m_balls[i], m_radius * m_balls.Length + m_halfDeviation + m_detailSize + lodVoxelSize);
+                sphere.Contains(ref queryAabb, out outerContainment);
+                if (outerContainment != ContainmentType.Disjoint)
+                    return ContainmentType.Intersects;
+            }
+
+            return ContainmentType.Disjoint;
+        }
+
+        internal override float SignedDistance(ref Vector3 position, float lodVoxelSize, IMyModule macroModulator, IMyModule detailModulator)
+        {
+            Vector3 localPosition = position - m_translation;
+
+            double sum = 0;
+            for (int i = 0; i < m_balls.Length; i++)
+            {
+                double distSquared = (localPosition - m_balls[i]).LengthSquared();
+                sum += m_weights[i] / distSquared;
+            }
+
+            float distance = (float)Math.Sqrt(1 / sum) * 2;
+            if ((m_innerRadius - lodVoxelSize) > distance)
+                return -1f;
+            if ((m_outerRadius + lodVoxelSize) < distance)
+                return 1f;
+
+            float halfDeviationRatio;
+            if (m_enableModulation)
+            {
+                Debug.Assert(m_deviationFrequency != 0f);
+                float normalizer = m_deviationFrequency * m_radius / distance;
+                var tmp = localPosition * normalizer;
+                halfDeviationRatio = (float)macroModulator.GetValue(tmp.X, tmp.Y, tmp.Z);
+            }
+            else
+            {
+                halfDeviationRatio = 0f;
+            }
+
+            float signedDistance = distance - m_radius - halfDeviationRatio * m_halfDeviation;
+            if (m_enableModulation && -m_detailSize < signedDistance && signedDistance < m_detailSize)
+            {
+                Debug.Assert(m_detailFrequency != 0f);
+                float normalizer = m_detailFrequency * m_radius / distance;
+                var tmp = localPosition * normalizer;
+                signedDistance += m_detailSize * (float)detailModulator.GetValue(tmp.X, tmp.Y, tmp.Z);
+            }
+
+            return signedDistance / lodVoxelSize;
+        }
+
+        internal override Vector3 Center()
+        {
+            return m_translation;
+        }
+
+        internal override void DebugDraw(ref Vector3D worldTranslation, Color color)
+        {
+            for (int i = 0; i < m_balls.Length; i++)
+                VRageRender.MyRenderProxy.DebugDrawSphere(worldTranslation + m_translation + m_balls[i], m_radius, color.ToVector3(), alpha: 0.5f, depthRead: true, smooth: false);
+        }
+
+        internal override MyCsgShapeBase DeepCopy()
+        {
+            return new MyCsgShapeMetaball(m_translation, m_balls, m_weights, m_radius, m_halfDeviation, m_deviationFrequency, m_detailFrequency);
+        }
+
+        internal override void ShrinkTo(float percentage)
+        {
+            m_radius *= percentage;
+            m_halfDeviation *= percentage;
+            ComputeDerivedProperties();
+        }
+
+        private void ComputeDerivedProperties()
+        {
+            m_outerRadius = m_radius + m_halfDeviation + m_detailSize;
+            m_innerRadius = m_radius - m_halfDeviation - m_detailSize;
+        }
+    }
+}

--- a/Sources/Sandbox.Game/Game/World/Generator/MyCompositeShapes.cs
+++ b/Sources/Sandbox.Game/Game/World/Generator/MyCompositeShapes.cs
@@ -496,6 +496,9 @@ namespace Sandbox.Game.World.Generator
                         switch (material.MinedOre)
                         {
                             case "Stone":
+                            case "Ice":
+                                frequency = 0;
+                                break;
                             case "Magnesium":
                             case "Silicon":
                                 frequency = lightOreFrequency;

--- a/Sources/Sandbox.Game/Game/World/Generator/MyCompositeShapes.cs
+++ b/Sources/Sandbox.Game/Game/World/Generator/MyCompositeShapes.cs
@@ -215,7 +215,7 @@ namespace Sandbox.Game.World.Generator
 
                 MyCsgShapeBase primaryShape;
                 { // determine primary shape
-                    var primaryType = random.Next() % 3;
+                    var primaryType = random.Next() % 5;
                     switch (primaryType)
                     {
                         case 0: //ShapeType.Torus
@@ -234,7 +234,7 @@ namespace Sandbox.Game.World.Generator
                             break;
 
                         case 1: //ShapeType.Sphere
-                        default:
+                        case 2:
                             {
                                 var sphere = new MyCsgSphere(
                                     translation: new Vector3(halfStorageSize),
@@ -243,6 +243,28 @@ namespace Sandbox.Game.World.Generator
                                     deviationFrequency: random.NextFloat() * 0.8f + 0.2f,
                                     detailFrequency: random.NextFloat() * 0.6f + 0.4f);
                                 primaryShape = sphere;
+                            }
+                            break;
+
+                        default: //ShapeType.Metaball
+                            {
+                                var balls = new Vector3[8];
+                                var weights = new float[8];
+                                for (int i = 0; i < balls.Length; i++)
+                                {
+                                    balls[i] = new Vector3(random.NextFloat(-0.25f, 0.25f) * size,
+                                        random.NextFloat(-0.25f, 0.25f) * size, random.NextFloat(-0.25f, 0.25f) * size);
+                                    weights[i] = i < 6 ? 1f : -1f;
+                                }
+                                var metaball = new MyCsgShapeMetaball(
+                                    translation: new Vector3(halfStorageSize),
+                                    radius: (random.NextFloat() * 0.1f + 0.2f) * size,
+                                    balls: balls,
+                                    weights: weights,
+                                    halfDeviation: (random.NextFloat() * 0.05f + 0.05f) * size + 1f,
+                                    deviationFrequency: random.NextFloat() * 0.8f + 0.2f,
+                                    detailFrequency: random.NextFloat() * 0.6f + 0.4f);
+                                primaryShape = metaball;                            
                             }
                             break;
                     }

--- a/Sources/Sandbox.Game/Sandbox.Game.csproj
+++ b/Sources/Sandbox.Game/Sandbox.Game.csproj
@@ -248,6 +248,7 @@
     <Compile Include="Engine\Utils\MyTextureAtlasUtils.cs" />
     <Compile Include="Engine\Voxels\IMyVoxelDrawable.cs" />
     <Compile Include="Engine\Voxels\MyCsgShapeExcludedSphere.cs" />
+    <Compile Include="Engine\Voxels\MyCsgShapeMetaball.cs" />
     <Compile Include="Engine\Voxels\MyCsgShapePlanet.cs" />
     <Compile Include="Engine\Voxels\MyCsgSimpleSphere.cs" />
     <Compile Include="Engine\Voxels\MyPrecalcJobPhysicsBatch.cs" />


### PR DESCRIPTION
Add a bit more realism and variety to the asteroid generator.

Warning: This will drastically change all the unmodified asteroids in an infinite game.

Add a metaball-based CSG primitive, and use it for the base solid on some asteroids. This generates an irregular bloblike shape that looks more like a real asteroid.

Change the way materials for asteroids are generated. Each asteroid is assigned to one of five classes, loosely based on real asteroid types. Each class has a different combination of surface and core material and in some cases an inner core material. Each class also has modified frequencies for the various ore types:
* Class C asteroids have an ice surface, stone core, and iron inner core. They have more light elements.
* Class S asteroids have a stone surface and iron core. They have more light elements.
* Class M asteroids have a stone surface and a nickel-iron core. They have more heavy elements.
* Class E asteroids are completely stone. They have more heavy elements and more ore deposits overall.
* Kuiper belt objects are completely ice. They have more light elements.

Overall, the material changes result in much less stone and iron, much more nickel and ice, and slightly (3-10%) increased frequency for other ores.

Screenshots: http://imgur.com/a/wiQsq