### PR TITLE
Send Message to PB via Laser Antenna

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyLaserAntenna.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyLaserAntenna.cs
@@ -16,5 +16,12 @@ namespace Sandbox.ModAPI.Ingame
         void SetTargetCoords(string coords);
 
         void Connect();
+
+        /// <summary>
+        /// Gets the linked receiver's IMyGridTerminalSystem. Returns null if no link is established.
+        /// </summary>
+        /// <returns></returns>
+        IMyGridTerminalSystem GetReceiverGrid();
+
     }
 }

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyLaserAntenna.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyLaserAntenna.cs
@@ -18,10 +18,20 @@ namespace Sandbox.ModAPI.Ingame
         void Connect();
 
         /// <summary>
-        /// Gets the linked receiver's IMyGridTerminalSystem. Returns null if no link is established.
+        /// Sets the argument for a specified programmable block connected to the current grid via laser antenna.
         /// </summary>
-        /// <returns></returns>
-        IMyGridTerminalSystem GetReceiverGrid();
+        /// <param name="pb_name">The name of the target programmable block for this message.</param>
+        /// <param name="message">The new argument string.</param>
+        /// <param name="run">Should the programmable block be run after the argument was changed.</param>
+        /// <returns>Returns true if the pb could be reached. False otherwise.</returns>
+        bool SendMessage(string pb_name, string message, bool run = false);
+
+        /// <summary>
+        /// Runs the script of a specified programmable block connected to the current grid via laser antenna.
+        /// </summary>
+        /// <param name="pb_name">The name of the target programmable block for this run command.</param>
+        /// <returns>Returns true if the pb could be reached. False otherwise.</returns>
+        bool SendRunCommand(string pb_name);
 
     }
 }

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyLaserAntenna.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyLaserAntenna.cs
@@ -18,20 +18,11 @@ namespace Sandbox.ModAPI.Ingame
         void Connect();
 
         /// <summary>
-        /// Sets the argument for a specified programmable block connected to the current grid via laser antenna.
+        /// Runs the script of a specified programmable block connected to the current grid via laser antenna with a custom argument.
         /// </summary>
         /// <param name="pb_name">The name of the target programmable block for this message.</param>
-        /// <param name="message">The new argument string.</param>
-        /// <param name="run">Should the programmable block be run after the argument was changed.</param>
+        /// <param name="message">The custom argument string.</param>
         /// <returns>Returns true if the pb could be reached. False otherwise.</returns>
-        bool SendMessage(string pb_name, string message, bool run = false);
-
-        /// <summary>
-        /// Runs the script of a specified programmable block connected to the current grid via laser antenna.
-        /// </summary>
-        /// <param name="pb_name">The name of the target programmable block for this run command.</param>
-        /// <returns>Returns true if the pb could be reached. False otherwise.</returns>
-        bool SendRunCommand(string pb_name);
-
+        bool SendMessage(string pb_name, string message);
     }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
@@ -750,13 +750,12 @@ namespace Sandbox.Game.Entities.Cube
         }
 
         /// <summary>
-        /// Sets the argument for a specified programmable block connected to the current grid via laser antenna.
+        /// Runs the script of a specified programmable block connected to the current grid via laser antenna with a custom argument.
         /// </summary>
         /// <param name="pb_name">The name of the target programmable block for this message.</param>
-        /// <param name="message">The new argument string.</param>
-        /// <param name="run">Should the programmable block be run after the argument was changed.</param>
+        /// <param name="message">The custom argument string.</param>
         /// <returns>Returns true if the pb could be reached. False otherwise.</returns>
-        public bool SendMessage(string pb_name, string message, bool run = false)
+        public bool SendMessage(string pb_name, string message)
         {
             if (pb_name == null || pb_name == string.Empty)
                 return false;
@@ -767,49 +766,15 @@ namespace Sandbox.Game.Entities.Cube
                 var terminalSystem = gridGroup.GroupData.TerminalSystem;
                 terminalSystem.UpdateGridBlocksOwnership(this.OwnerId);
 
-                IMyGridTerminalSystem Igrid = (IMyGridTerminalSystem)terminalSystem;
-                if (Igrid == null)
+                IMyGridTerminalSystem grid = (IMyGridTerminalSystem)terminalSystem;
+                if (grid == null)
                     return false;
 
-                MyProgrammableBlock pb = (MyProgrammableBlock)Igrid.GetBlockWithName(pb_name); //Get the programmable block with the specified name.
+                MyProgrammableBlock pb = (MyProgrammableBlock)grid.GetBlockWithName(pb_name); //Get the programmable block with the specified name.
                 if (pb == null) //If the block with the name does not exist, or if the player has no permission this will be null.
                     return false;
 
-                pb.TerminalRunArgument = message;
-                if (run)
-                    pb.Run();
-
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Runs the script of a specified programmable block connected to the current grid via laser antenna.
-        /// </summary>
-        /// <param name="pb_name">The name of the target programmable block for this run command.</param>
-        /// <returns>Returns true if the pb could be reached. False otherwise.</returns>
-        public bool SendRunCommand(string pb_name)
-        {
-            if (pb_name == null)
-                return false;
-
-            if (State == StateEnum.connected)
-            {
-                var gridGroup = MyCubeGridGroups.Static.Logical.GetGroup(GetOther().CubeGrid);
-                var terminalSystem = gridGroup.GroupData.TerminalSystem;
-                terminalSystem.UpdateGridBlocksOwnership(this.OwnerId);
-
-                IMyGridTerminalSystem Igrid = (IMyGridTerminalSystem)terminalSystem;
-                if (Igrid == null)
-                    return false;
-
-                MyProgrammableBlock pb = (MyProgrammableBlock)Igrid.GetBlockWithName(pb_name); //Get the programmable block with the specified name.
-                if (pb == null) //If the block with the name does not exist, or if the player has no permission this will be null.
-                    return false;
-
-                pb.Run();
+                pb.Run(message);
 
                 return true;
             }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
@@ -750,21 +750,71 @@ namespace Sandbox.Game.Entities.Cube
         }
 
         /// <summary>
-        /// Gets the linked receiver's IMyGridTerminalSystem. Returns null if no link is established.
+        /// Sets the argument for a specified programmable block connected to the current grid via laser antenna.
         /// </summary>
-        /// <returns></returns>
-        public IMyGridTerminalSystem GetReceiverGrid()
+        /// <param name="pb_name">The name of the target programmable block for this message.</param>
+        /// <param name="message">The new argument string.</param>
+        /// <param name="run">Should the programmable block be run after the argument was changed.</param>
+        /// <returns>Returns true if the pb could be reached. False otherwise.</returns>
+        public bool SendMessage(string pb_name, string message, bool run = false)
         {
+            if (pb_name == null || pb_name == string.Empty)
+                return false;
+
             if (State == StateEnum.connected)
             {
                 var gridGroup = MyCubeGridGroups.Static.Logical.GetGroup(GetOther().CubeGrid);
                 var terminalSystem = gridGroup.GroupData.TerminalSystem;
                 terminalSystem.UpdateGridBlocksOwnership(this.OwnerId);
 
-                return (IMyGridTerminalSystem)terminalSystem;
+                IMyGridTerminalSystem Igrid = (IMyGridTerminalSystem)terminalSystem;
+                if (Igrid == null)
+                    return false;
+
+                MyProgrammableBlock pb = (MyProgrammableBlock)Igrid.GetBlockWithName(pb_name); //Get the programmable block with the specified name.
+                if (pb == null) //If the block with the name does not exist, or if the player has no permission this will be null.
+                    return false;
+
+                pb.TerminalRunArgument = message;
+                if (run)
+                    pb.Run();
+
+                return true;
             }
 
-            return null;
+            return false;
+        }
+
+        /// <summary>
+        /// Runs the script of a specified programmable block connected to the current grid via laser antenna.
+        /// </summary>
+        /// <param name="pb_name">The name of the target programmable block for this run command.</param>
+        /// <returns>Returns true if the pb could be reached. False otherwise.</returns>
+        public bool SendRunCommand(string pb_name)
+        {
+            if (pb_name == null)
+                return false;
+
+            if (State == StateEnum.connected)
+            {
+                var gridGroup = MyCubeGridGroups.Static.Logical.GetGroup(GetOther().CubeGrid);
+                var terminalSystem = gridGroup.GroupData.TerminalSystem;
+                terminalSystem.UpdateGridBlocksOwnership(this.OwnerId);
+
+                IMyGridTerminalSystem Igrid = (IMyGridTerminalSystem)terminalSystem;
+                if (Igrid == null)
+                    return false;
+
+                MyProgrammableBlock pb = (MyProgrammableBlock)Igrid.GetBlockWithName(pb_name); //Get the programmable block with the specified name.
+                if (pb == null) //If the block with the name does not exist, or if the player has no permission this will be null.
+                    return false;
+
+                pb.Run();
+
+                return true;
+            }
+
+            return false;
         }
 
         public void AddBroadcastersContactingMe(ref HashSet<MyDataBroadcaster> broadcasters)

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
@@ -749,6 +749,24 @@ namespace Sandbox.Game.Entities.Cube
             return null;
         }
 
+        /// <summary>
+        /// Gets the linked receiver's IMyGridTerminalSystem. Returns null if no link is established.
+        /// </summary>
+        /// <returns></returns>
+        public IMyGridTerminalSystem GetReceiverGrid()
+        {
+            if (State == StateEnum.connected)
+            {
+                var gridGroup = MyCubeGridGroups.Static.Logical.GetGroup(GetOther().CubeGrid);
+                var terminalSystem = gridGroup.GroupData.TerminalSystem;
+                terminalSystem.UpdateGridBlocksOwnership(this.OwnerId);
+
+                return (IMyGridTerminalSystem)terminalSystem;
+            }
+
+            return null;
+        }
+
         public void AddBroadcastersContactingMe(ref HashSet<MyDataBroadcaster> broadcasters)
         {//adds all broadcasters trying to contact me
         //these will be received and updated, but they do not relay information about others (only two way established link can do that)


### PR DESCRIPTION
This addition enables users to set the argument of a programmable block which is connected to the current grid by a pair of Laser Antenna.

It also adds a method to run the script of said pb.