### PR TITLE
Include weapon pins in IK calculation

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Character/MyCharacter.UpdateAnimations.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Character/MyCharacter.UpdateAnimations.cs
@@ -380,14 +380,16 @@ namespace Sandbox.Game.Entities.Character
                         UpdateWeaponPosition(); //mainly IK and some zoom + ironsight stuff
                         if (m_handItemDefinition.SimulateLeftHand && m_leftHandIKStartBone != -1 && m_leftHandIKEndBone != -1 && (!UseAnimationForWeapon && m_animationToIKState == 0))
                         {
-                            MatrixD leftHand = (MatrixD)m_handItemDefinition.LeftHand * ((MyEntity)m_currentWeapon).WorldMatrix;
+                            MatrixD offsetMatrix = MatrixD.Invert(m_bones[m_leftHandItemBone].BindTransform);
+                            MatrixD leftHand = offsetMatrix * (MatrixD)m_handItemDefinition.LeftHand * ((MyEntity)m_currentWeapon).WorldMatrix;
                             CalculateHandIK(m_leftHandIKStartBone, m_leftForearmBone, m_leftHandIKEndBone, ref leftHand);
                             //CalculateHandIK(m_leftHandIKStartBone, m_leftHandIKEndBone, ref leftHand);
                         }
 
                         if (m_handItemDefinition.SimulateRightHand && m_rightHandIKStartBone != -1 && m_rightHandIKEndBone != -1 && (!UseAnimationForWeapon || m_animationToIKState != 0))
                         {
-                            MatrixD rightHand = (MatrixD)m_handItemDefinition.RightHand * ((MyEntity)m_currentWeapon).WorldMatrix;
+                            MatrixD offsetMatrix = MatrixD.Invert(m_bones[m_rightHandItemBone].BindTransform);
+                            MatrixD rightHand = offsetMatrix * (MatrixD)m_handItemDefinition.RightHand * ((MyEntity)m_currentWeapon).WorldMatrix;
                             CalculateHandIK(m_rightHandIKStartBone, m_rightForearmBone, m_rightHandIKEndBone, ref rightHand);
                             //CalculateHandIK(m_rightHandIKStartBone, m_rightHandIKEndBone, ref rightHand);
                         }


### PR DESCRIPTION
#### Summary

This (small) patch includes the weapon pins (aka ItemBones) into the IK calculation, allowing modders to adjust hand item placement for custom characters. After applying this patch, the hand item positions in `HandItems.sbc` will need to be readjusted.

#### Background

I'm working on a custom character (with a custom skeleton) and ran into the issue that I couldn't adjust the item placement in my character's hands. The default astronaut skeleton includes the bones `SE_RigL_Weapon_pin` and `SE_RigR_Weapon_pin`, which are attached to the wrists. They are assigned as `LeftHandItemBone` and `RightHandItemBone` in the character configuration. Obviously these are meant to be used to adjust the item placement in the character's hands, however they weren't used anywhere in the code. 