### PR TITLE
Allow guns with infinite ammo.

### DIFF
--- a/Sources/Sandbox.Game/Game/Weapons/Guns/MyGunBase.cs
+++ b/Sources/Sandbox.Game/Game/Weapons/Guns/MyGunBase.cs
@@ -346,6 +346,9 @@ namespace Sandbox.Game.Weapons
 
         public bool HasEnoughAmmunition()
         {
+            if (WeaponProperties.AmmoMagazineDefinition.Capacity == 0)
+                return true;
+
             if (CurrentAmmo < AMMO_PER_SHOOT) // so far it is always one bullet per shot. If anything, WeaponDefinition has to be extended.
             {
                 return m_user.AmmoInventory.GetItemAmount(CurrentAmmoMagazineId) > 0;
@@ -355,6 +358,9 @@ namespace Sandbox.Game.Weapons
 
         public void ConsumeAmmo()
         {
+            if (WeaponProperties.AmmoMagazineDefinition.Capacity == 0)
+                return;
+
             CurrentAmmo -= AMMO_PER_SHOOT;
             if (CurrentAmmo == -1)
             {


### PR DESCRIPTION
This patch makes it so setting the capacity of an ammo magazine to 0 gives it infinite ammo. It's not necessary to actually have a magazine in the gun's inventory, simply having a capacity-0 magazine as the magazine type will allow infinite fire.

This is intended to be used by mods that add laser weapons.