### PR TITLE
Fixed #21 Oxygen 100% bottle disassembles indefinitely.

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Inventory/MyInventory.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Inventory/MyInventory.cs
@@ -594,17 +594,6 @@ namespace Sandbox.Game
 
                     MyInventoryItem item = src.m_items[i];
 
-                    //TODO(AF) Remove oxygen specific code from inventory.
-                    //Will be fixed once MyInventory will support Entities.
-                    var oxygenBottle = item.Content as MyObjectBuilder_OxygenContainerObject;
-                    if (oxygenBottle != null && oxygenBottle.OxygenLevel == 1f)
-                    {
-                        i++;
-                        continue;
-                    }
-                    // End of oxygen specific code
-
-
                     if (item.Content.GetObjectId() != contentId)
                     {
                         i++;


### PR DESCRIPTION
Is this code required in some case?
It prevents 100% full oxygen bottles to be disassembled correctly.
You gain back raw materials **and** the oxygen bottle.