### PR TITLE
#96 Added Ingame Assembler Functions

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyAssembler.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyAssembler.cs
@@ -8,5 +8,7 @@ namespace Sandbox.ModAPI.Ingame
     public interface IMyAssembler : IMyProductionBlock
     {
         bool DisassembleEnabled { get; }
+        bool QueueItem(string itemType, string subtypeName, int amount);
+        void ClearQueue();
     }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
@@ -1065,5 +1065,22 @@ namespace Sandbox.Game.Entities.Cube
         {
             return base.GetOperationalPowerConsumption() * (1f + UpgradeValues["Productivity"]) * (1f / UpgradeValues["PowerEfficiency"]);
         }
+
+        bool Sandbox.ModAPI.Ingame.IMyAssembler.QueueItem(string itemType, string subtypeName, int amount)
+        {
+            try
+            {
+                InsertQueueItemRequest(-1,
+                                       MyDefinitionManager.Static.TryGetBlueprintDefinitionByResultId(new MyDefinitionId(MyObjectBuilderType.Parse(itemType), subtypeName)),
+                                       (VRage.MyFixedPoint)amount);
+            }
+            catch { return false; } // User probably entered invalid type or name
+            return true;
+        }
+
+        void Sandbox.ModAPI.Ingame.IMyAssembler.ClearQueue()
+        {
+            ClearQueue();
+        }
     }
 }


### PR DESCRIPTION
Added Ingame Assembler functions QueueItem and ClearQueue to enable
players to be able to queue items in the assembler and clear the queue.
QueueItem has three parameters, string itemType (I.e.
MyObjectBuilder_Component), string subtypeName(I.e. SteelPlate), int
amount
QueueItem returns bool: true if item was queued, false if not. False
indicates invalid type or subtype name.

ClearItem has no parameters

Both functions work in either assemble mode or disassemble mode.