### PR TITLE
Issue #74 Moddable custom fonts for LCDs

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyTextPanel.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyTextPanel.cs
@@ -7,6 +7,10 @@ namespace Sandbox.ModAPI.Ingame
 {
     public interface IMyTextPanel : IMyFunctionalBlock
     {
+        string Font { get; }
+        void GetFonts(List<string> ids);
+        void SetFont(string id);
+
         bool WritePublicText(string value, bool append = false);
         string GetPublicText();
 

--- a/Sources/Sandbox.Common/MyEnums.cs
+++ b/Sources/Sandbox.Common/MyEnums.cs
@@ -35,6 +35,8 @@ namespace Sandbox.Common
 
         BuildInfo,
         BuildInfoHighlight,
+
+        Monospace,
     }
 
     //  Material type of a physical object. This value determine sound of collision, decal type, explosion type, etc.

--- a/Sources/Sandbox.Common/MyEnums.cs
+++ b/Sources/Sandbox.Common/MyEnums.cs
@@ -35,8 +35,6 @@ namespace Sandbox.Common
 
         BuildInfo,
         BuildInfoHighlight,
-
-        Monospace,
     }
 
     //  Material type of a physical object. This value determine sound of collision, decal type, explosion type, etc.

--- a/Sources/Sandbox.Common/ObjectBuilders/Definitions/MyObjectBuilder_Definitions.cs
+++ b/Sources/Sandbox.Common/ObjectBuilders/Definitions/MyObjectBuilder_Definitions.cs
@@ -156,7 +156,7 @@ namespace Sandbox.Common.ObjectBuilders.Definitions
         [XmlArrayItem("LCDTextureDefinition")]
         [ProtoMember(36)]
         public MyObjectBuilder_LCDTextureDefinition[] LCDTextures;
-
+        
         [XmlArrayItem("Bot")]
         [ProtoMember(37)]
         public MyObjectBuilder_BotDefinition[] Bots;
@@ -204,5 +204,9 @@ namespace Sandbox.Common.ObjectBuilders.Definitions
         [XmlArrayItem("Entry")]
         [ProtoMember(48)]
         public EnvironmentItemsEntry[] EnvironmentItemsEntries;
+        
+        [XmlArrayItem("LCDFontDefinition")]
+        [ProtoMember(49)]
+        public MyObjectBuilder_LCDFontDefinition[] LCDFonts;
     }
 }

--- a/Sources/Sandbox.Common/ObjectBuilders/Definitions/MyObjectBuilder_LCDFontDefinition.cs
+++ b/Sources/Sandbox.Common/ObjectBuilders/Definitions/MyObjectBuilder_LCDFontDefinition.cs
@@ -1,0 +1,27 @@
+﻿using System.Xml.Serialization;
+using ProtoBuf;
+using VRage.Data;
+
+namespace Sandbox.Common.ObjectBuilders.Definitions
+{
+    [ProtoContract]
+    [MyObjectBuilderDefinition]
+    public class MyObjectBuilder_LCDFontDefinition : MyObjectBuilder_DefinitionBase
+    {
+        [ProtoContract]
+        public class MyFontTexturePathDefinition
+        {
+            [ProtoMember(1)]
+            [ModdableContentFile("dds")]
+            public string Path;
+        }
+
+        [ProtoMember(1)]
+        [ModdableContentFile("xml")]
+        public string FontDataPath;
+
+        [ProtoMember(2)]
+        [XmlArrayItem("FontTexture")]
+        public MyFontTexturePathDefinition[] FontTextures;
+    }
+}

--- a/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_TextPanel.cs
+++ b/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_TextPanel.cs
@@ -70,7 +70,7 @@ namespace Sandbox.Common.ObjectBuilders
         public int CurrentShownTexture = 0;
 
         [ProtoMember(13)]
-        public MyFontEnum FontFace = MyFontEnum.Debug;
+        public string FontName = null;
 
     }
 }

--- a/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_TextPanel.cs
+++ b/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_TextPanel.cs
@@ -69,5 +69,8 @@ namespace Sandbox.Common.ObjectBuilders
         [ProtoMember(12)]
         public int CurrentShownTexture = 0;
 
+        [ProtoMember(13)]
+        public MyFontEnum FontFace = MyFontEnum.Debug;
+
     }
 }

--- a/Sources/Sandbox.Common/Sandbox.Common.csproj
+++ b/Sources/Sandbox.Common/Sandbox.Common.csproj
@@ -311,6 +311,7 @@
     <Compile Include="ObjectBuilders\Definitions\MyObjectBuilder_ControllerSchemaDefinition.cs" />
     <Compile Include="ObjectBuilders\Definitions\MyObjectBuilder_CryoChamberDefinition.cs" />
     <Compile Include="ObjectBuilders\Definitions\MyObjectBuilder_EnvironmentItemsDefinition.cs" />
+    <Compile Include="ObjectBuilders\Definitions\MyObjectBuilder_LCDFontDefinition.cs" />
     <Compile Include="ObjectBuilders\Definitions\MyObjectBuilder_MaterialSoundsDefinition.cs" />
     <Compile Include="ObjectBuilders\Components\MyObjectBuilder_ScriptManager.cs" />
     <Compile Include="ObjectBuilders\Definitions\AI\MyObjectBuilder_BlockNavigationDefinition.cs" />

--- a/Sources/Sandbox.Game/Definitions/MyDefinitionManager.cs
+++ b/Sources/Sandbox.Game/Definitions/MyDefinitionManager.cs
@@ -504,6 +504,12 @@ namespace Sandbox.Definitions
                 InitLCDTextureCategories(context, definitionSet.m_definitionsById, objBuilder.LCDTextures, failOnDebug);
             }
 
+            if (objBuilder.LCDFonts != null)
+            {
+                MySandboxGame.Log.WriteLine("Loading LCD font categories");
+                InitLCDFontCategories(context, definitionSet.m_definitionsById, objBuilder.LCDFonts, failOnDebug);
+            }
+
             if (objBuilder.AIBehaviors != null)
             {
                 MySandboxGame.Log.WriteLine("Loading behaviors");
@@ -1087,6 +1093,16 @@ namespace Sandbox.Definitions
                 var newCategory = InitDefinition<MyLCDTextureDefinition>(context, LCDTextureCategory);
                 Check(!output.ContainsKey(LCDTextureCategory.Id), LCDTextureCategory.Id, failOnDebug);          
                 output[LCDTextureCategory.Id] = newCategory;
+            }
+        }
+
+        private void InitLCDFontCategories(MyModContext context, DefinitionDictionary<MyDefinitionBase> output, MyObjectBuilder_LCDFontDefinition[] categories, bool failOnDebug = true)
+        {
+            foreach (var LCDFontCategory in categories)
+            {
+                var newCategory = InitDefinition<MyLCDFontDefinition>(context, LCDFontCategory);
+                Check(!output.ContainsKey(LCDFontCategory.Id), LCDFontCategory.Id, failOnDebug);          
+                output[LCDFontCategory.Id] = newCategory;
             }
         }
         private void InitBlueprintClasses(MyModContext context,
@@ -2053,6 +2069,11 @@ namespace Sandbox.Definitions
         public ListReader<MyLCDTextureDefinition> GetLCDTexturesDefinitions()
         {
             return new ListReader<MyLCDTextureDefinition>(m_definitions.m_definitionsById.Values.OfType<MyLCDTextureDefinition>().ToList());
+        }
+
+        public ListReader<MyLCDFontDefinition> GetLCDFontDefinitions()
+        {
+            return new ListReader<MyLCDFontDefinition>(m_definitions.m_definitionsById.Values.OfType<MyLCDFontDefinition>().ToList());
         }
 
         public ListReader<MyBehaviorDefinition> GetBehaviorDefinitions()

--- a/Sources/Sandbox.Game/Definitions/MyLCDFontDefinition.cs
+++ b/Sources/Sandbox.Game/Definitions/MyLCDFontDefinition.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using Sandbox.Common.ObjectBuilders.Definitions;
+
+namespace Sandbox.Definitions
+{
+    [MyDefinitionType(typeof(MyObjectBuilder_LCDFontDefinition))]
+    public class MyLCDFontDefinition : MyDefinitionBase
+    {
+        public string FontDataPath;
+        public string[] FontTexturePathes;
+
+        protected override void Init(MyObjectBuilder_DefinitionBase builder)
+        {
+            base.Init(builder);
+
+            var LCDFontBuilder = builder as MyObjectBuilder_LCDFontDefinition;
+            if (LCDFontBuilder != null)
+            {
+                this.FontDataPath = LCDFontBuilder.FontDataPath;
+                if (LCDFontBuilder.FontTextures != null)
+                {
+                    this.FontTexturePathes = LCDFontBuilder.FontTextures.Select(_ => _.Path).ToArray();
+                }
+                else
+                {
+                    this.FontTexturePathes = new string[0];
+                }
+            }
+        }
+    }
+}

--- a/Sources/Sandbox.Game/Game/Components/Renders/MyRenderComponentTextPanel.cs
+++ b/Sources/Sandbox.Game/Game/Components/Renders/MyRenderComponentTextPanel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Sandbox.Common;
 using Sandbox.Common.Components;
 using VRageRender;
 using VRageMath;
@@ -23,9 +24,9 @@ namespace Sandbox.Game.Components
         {
             MyRenderProxy.ChangeMaterialTexture(this.RenderObjectIDs[0], PANEL_MATERIAL_NAME, path);
         }
-        public void RenderTextToTexture(long entityId,string text, float scale, Color fontColor, Color backgroundColor, int textureResolution,int aspectRatio)
+        public void RenderTextToTexture(long entityId,string text, float scale, Color fontColor, Color backgroundColor, int textureResolution,int aspectRatio, MyFontEnum font)
         {
-            MyRenderProxy.RenderTextToTexture(RenderObjectIDs[0], entityId, PANEL_MATERIAL_NAME, text, scale, fontColor, backgroundColor, textureResolution, aspectRatio);
+            MyRenderProxy.RenderTextToTexture(RenderObjectIDs[0], entityId, PANEL_MATERIAL_NAME, text, scale, fontColor, backgroundColor, textureResolution, aspectRatio, (int)font);
         }
         public void ReleaseRenderTexture()
         {

--- a/Sources/Sandbox.Game/Game/Components/Renders/MyRenderComponentTextPanel.cs
+++ b/Sources/Sandbox.Game/Game/Components/Renders/MyRenderComponentTextPanel.cs
@@ -24,9 +24,9 @@ namespace Sandbox.Game.Components
         {
             MyRenderProxy.ChangeMaterialTexture(this.RenderObjectIDs[0], PANEL_MATERIAL_NAME, path);
         }
-        public void RenderTextToTexture(long entityId,string text, float scale, Color fontColor, Color backgroundColor, int textureResolution,int aspectRatio, MyFontEnum font)
+        public void RenderTextToTexture(long entityId,string text, float scale, Color fontColor, Color backgroundColor, int textureResolution,int aspectRatio, string fontPath)
         {
-            MyRenderProxy.RenderTextToTexture(RenderObjectIDs[0], entityId, PANEL_MATERIAL_NAME, text, scale, fontColor, backgroundColor, textureResolution, aspectRatio, (int)font);
+            MyRenderProxy.RenderTextToTexture(RenderObjectIDs[0], entityId, PANEL_MATERIAL_NAME, text, scale, fontColor, backgroundColor, textureResolution, aspectRatio, fontPath);
         }
         public void ReleaseRenderTexture()
         {

--- a/Sources/Sandbox.Game/ModAPI/Blocks/MyTextPanel_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/Blocks/MyTextPanel_ModAPI.cs
@@ -14,6 +14,21 @@ namespace Sandbox.Game.Entities.Blocks
         private StringBuilder m_publicDescriptionHelper = new StringBuilder();
         private StringBuilder m_privateDescriptionHelper = new StringBuilder();
 
+        string ModAPI.Ingame.IMyTextPanel.Font { get { return Font; } }
+
+        void ModAPI.Ingame.IMyTextPanel.GetFonts(List<string> ids)
+        {
+            foreach (var definition in m_fontDefinitions)
+            {
+                ids.Add(definition.Id.SubtypeName);
+            }
+        }
+
+        void ModAPI.Ingame.IMyTextPanel.SetFont(string id)
+        {
+            Font = id;
+        }
+
         void ModAPI.Ingame.IMyTextPanel.ShowPublicTextOnScreen()
         {
             SyncObject.SendShowOnScreenChangeRequest((byte)ShowTextOnScreenFlag.PUBLIC);

--- a/Sources/Sandbox.Game/MySandboxGame.cs
+++ b/Sources/Sandbox.Game/MySandboxGame.cs
@@ -1038,14 +1038,14 @@ namespace Sandbox
         {
             MyGuiSandbox.LoadContent(new MyFontDescription[]
             {
-                new MyFontDescription { Id = MyFontEnum.Debug,          Path = @"Fonts\white_shadow\FontData.xml", IsDebug = true },
-                new MyFontDescription { Id = MyFontEnum.Red,            Path = @"Fonts\red\FontData.xml" },
-                new MyFontDescription { Id = MyFontEnum.Green,          Path = @"Fonts\green\FontData.xml" },
-                new MyFontDescription { Id = MyFontEnum.Blue,           Path = @"Fonts\blue\FontData.xml" },
-                new MyFontDescription { Id = MyFontEnum.White,          Path = @"Fonts\white\FontData.xml" },
-                new MyFontDescription { Id = MyFontEnum.DarkBlue,       Path = @"Fonts\DarkBlue\FontData.xml" },
-                new MyFontDescription { Id = MyFontEnum.UrlNormal,      Path = @"Fonts\blue\FontData.xml" },
-                new MyFontDescription { Id = MyFontEnum.UrlHighlight,   Path = @"Fonts\white\FontData.xml" },
+                new MyFontDescription { Id = MyFontEnum.Debug,                  Path = @"Fonts\white_shadow\FontData.xml", IsDebug = true },
+                new MyFontDescription { Id = MyFontEnum.Red,                    Path = @"Fonts\red\FontData.xml" },
+                new MyFontDescription { Id = MyFontEnum.Green,                  Path = @"Fonts\green\FontData.xml" },
+                new MyFontDescription { Id = MyFontEnum.Blue,                   Path = @"Fonts\blue\FontData.xml" },
+                new MyFontDescription { Id = MyFontEnum.White,                  Path = @"Fonts\white\FontData.xml" },
+                new MyFontDescription { Id = MyFontEnum.DarkBlue,               Path = @"Fonts\DarkBlue\FontData.xml" },
+                new MyFontDescription { Id = MyFontEnum.UrlNormal,              Path = @"Fonts\blue\FontData.xml" },
+                new MyFontDescription { Id = MyFontEnum.UrlHighlight,           Path = @"Fonts\white\FontData.xml" },
 
                 new MyFontDescription { Id = MyFontEnum.ErrorMessageBoxCaption, Path = @"Fonts\white\FontData.xml" },
                 new MyFontDescription { Id = MyFontEnum.ErrorMessageBoxText,    Path = @"Fonts\red\FontData.xml" },
@@ -1056,6 +1056,8 @@ namespace Sandbox
                 new MyFontDescription { Id = MyFontEnum.LoadingScreen,          Path = @"Fonts\blue\FontData.xml" },
                 new MyFontDescription { Id = MyFontEnum.BuildInfo,              Path = @"Fonts\blue\FontData.xml" },
                 new MyFontDescription { Id = MyFontEnum.BuildInfoHighlight,     Path = @"Fonts\red\FontData.xml" },
+
+                new MyFontDescription { Id = MyFontEnum.Monospace,              Path = @"Fonts\monospace\FontData.xml" },
             });
         }
 

--- a/Sources/Sandbox.Game/MySandboxGame.cs
+++ b/Sources/Sandbox.Game/MySandboxGame.cs
@@ -1056,8 +1056,6 @@ namespace Sandbox
                 new MyFontDescription { Id = MyFontEnum.LoadingScreen,          Path = @"Fonts\blue\FontData.xml" },
                 new MyFontDescription { Id = MyFontEnum.BuildInfo,              Path = @"Fonts\blue\FontData.xml" },
                 new MyFontDescription { Id = MyFontEnum.BuildInfoHighlight,     Path = @"Fonts\red\FontData.xml" },
-
-                new MyFontDescription { Id = MyFontEnum.Monospace,              Path = @"Fonts\monospace\FontData.xml" },
             });
         }
 

--- a/Sources/Sandbox.Game/Sandbox.Game.csproj
+++ b/Sources/Sandbox.Game/Sandbox.Game.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Definitions\MyEnvironmentItemsDefinition.cs" />
     <Compile Include="Definitions\MyHumanoidBotDefinition.cs" />
     <Compile Include="Definitions\MyLaserAntennaDefinition.cs" />
+    <Compile Include="Definitions\MyLCDFontDefinition.cs" />
     <Compile Include="Definitions\MyOxygenContainerDefinition.cs" />
     <Compile Include="Definitions\MyOxygenFarmDefinition.cs" />
     <Compile Include="Definitions\MyOxygenGeneratorDefinition.cs" />

--- a/Sources/VRage.Render/MyDebugDraw.cs
+++ b/Sources/VRage.Render/MyDebugDraw.cs
@@ -834,6 +834,29 @@ namespace VRageRender
 
             return textLength;
         }
+
+        public static float DrawText(Vector2 screenCoord, StringBuilder text, Color color, float scale, bool depthRead, BlendState blendState, MyRenderFont font, MyGuiDrawAlignEnum align = MyGuiDrawAlignEnum.HORISONTAL_LEFT_AND_VERTICAL_TOP)
+        {
+            if (depthRead)
+                DepthStencilState.DepthRead.Apply();
+            else
+                DepthStencilState.None.Apply();
+            
+            if (font == null)
+            {
+                font = MyRender.GetDebugFont();
+            }
+            
+            MyRender.BeginSpriteBatch(blendState);
+
+            Vector2 textSize = font.MeasureString(text, scale);
+            screenCoord = MyUtils.GetCoordAligned(screenCoord, textSize, align);
+            float textLength = font.DrawString(screenCoord, color, text, scale);
+
+            MyRender.EndSpriteBatch();
+
+            return textLength;
+        }
         public static void DrawText(Vector3D worldCoord, StringBuilder text, Color color, float scale, bool depthRead, MyGuiDrawAlignEnum align = MyGuiDrawAlignEnum.HORISONTAL_LEFT_AND_VERTICAL_TOP, int customViewProjection = -1)
         {
             System.Diagnostics.Debug.Assert(customViewProjection == -1 || MyRenderProxy.BillboardsViewProjectionRead.ContainsKey(customViewProjection));

--- a/Sources/VRage.Render/MyDebugDraw.cs
+++ b/Sources/VRage.Render/MyDebugDraw.cs
@@ -806,18 +806,29 @@ namespace VRageRender
             return DrawText(screenCoord, text, color, scale, depthRead, MyStateObjects.GuiDefault_BlendState, align);
         }
 
-        public static float DrawText(Vector2 screenCoord, StringBuilder text, Color color, float scale, bool depthRead, BlendState blendState, MyGuiDrawAlignEnum align = MyGuiDrawAlignEnum.HORISONTAL_LEFT_AND_VERTICAL_TOP)
+        public static float DrawText(Vector2 screenCoord, StringBuilder text, Color color, float scale, bool depthRead, BlendState blendState, MyGuiDrawAlignEnum align = MyGuiDrawAlignEnum.HORISONTAL_LEFT_AND_VERTICAL_TOP, int fontIndex = -1)
         {
             if (depthRead)
                 DepthStencilState.DepthRead.Apply();
             else
                 DepthStencilState.None.Apply();
 
+            MyRenderFont renderFont = null;
+            if (fontIndex >= 0)
+            {
+                renderFont = MyRender.TryGetFont(fontIndex);
+            }
+
+            if (renderFont == null)
+            {
+                renderFont = MyRender.GetDebugFont();
+            }
+            
             MyRender.BeginSpriteBatch(blendState);
 
-            Vector2 textSize = MyRender.GetDebugFont().MeasureString(text, scale);
+            Vector2 textSize = renderFont.MeasureString(text, scale);
             screenCoord = MyUtils.GetCoordAligned(screenCoord, textSize, align);
-            float textLength = MyRender.GetDebugFont().DrawString(screenCoord, color, text, scale);
+            float textLength = renderFont.DrawString(screenCoord, color, text, scale);
 
             MyRender.EndSpriteBatch();
 

--- a/Sources/VRage.Render/MyRender-Content.cs
+++ b/Sources/VRage.Render/MyRender-Content.cs
@@ -121,6 +121,7 @@ namespace VRageRender
         static readonly MyEffectBase[] m_effects = new MyEffectBase[Enum.GetValues(typeof(MyEffects)).GetLength(0)];
         static Texture m_randomTexture = null;
         static SortedDictionary<int, MyRenderFont> m_fontsById = new SortedDictionary<int, MyRenderFont>();
+        static Dictionary<string, MyRenderFont> m_customFonts = new Dictionary<string, MyRenderFont>();
         static MyRenderFont m_debugFont;
         static Dictionary<int, MyRenderComponentBase> m_renderComponents = new Dictionary<int, MyRenderComponentBase>();
 
@@ -335,6 +336,12 @@ namespace VRageRender
             m_farObjectsPrunningStructure.Clear();
             m_atmospherePurunnigStructure.Clear();
             m_nearObjects.Clear();
+
+            foreach (var customFont in m_customFonts)
+            {
+                customFont.Value.UnloadContent();
+            }
+            m_customFonts.Clear();
 
             Clear();
 
@@ -885,6 +892,10 @@ namespace VRageRender
             return m_postProcesses;
         }
 
+        #endregion
+
+        #region Fonts
+
         internal static MyRenderFont GetDebugFont()
         {
             return m_debugFont;
@@ -899,6 +910,23 @@ namespace VRageRender
         {
             MyRenderFont font;
             m_fontsById.TryGetValue(id, out font);
+            return font;
+        }
+
+        internal static MyRenderFont GetOrLoadCustomFont(string path)
+        {
+            MyRenderFont font;
+            if (!m_customFonts.TryGetValue(path, out font))
+            {
+                font = new MyRenderFont(path);
+                if (!font.LoadContent())
+                {
+                    // Unable to load custom font, fallback to default (debug) font
+                    MyLog.Default.WriteLine(string.Format("ERROR Failed to load custom font '{0}'", path));
+                    font = m_debugFont;
+                }
+                m_customFonts.Add(path, font);
+            }
             return font;
         }
 

--- a/Sources/VRage.Render/MyRender-Draw.cs
+++ b/Sources/VRage.Render/MyRender-Draw.cs
@@ -638,6 +638,29 @@ namespace VRageRender
             return renderTexture;
         }
 
+        private static Texture RenderTextToTexture(MyRenderTextureId objectId, string text, float scale, Color fontColor, Color backgroundColor, int resolution, int aspectRatio, string fontPath)
+        {
+            if (m_screenshot != null)
+            {
+                return null;
+            }
+            Texture renderTexture = MyRenderTexturePool.GetRenderTexture(objectId, resolution, aspectRatio);
+            if (renderTexture != null)
+            {
+                MyRender.SetRenderTarget(renderTexture, null);
+
+                var surfaceDesc = renderTexture.GetLevelDescription(0);
+                MyRender.GraphicsDevice.Clear(ClearFlags.Target, new SharpDX.ColorBGRA(backgroundColor.R, backgroundColor.G, backgroundColor.B, 0), 1, 0);
+                MyRender.SetDeviceViewport(new SharpDX.Viewport(0, 0, surfaceDesc.Width, surfaceDesc.Height));
+                
+                var font = MyRender.GetOrLoadCustomFont(fontPath);
+                MyDebugDraw.DrawText(Vector2.Zero, new StringBuilder(text), fontColor, scale * MyRenderTexturePool.RenderQualityScale(), false, BlendState.EmissiveTexture, font);
+
+                MyRender.SetRenderTarget(null, null);
+            }
+            return renderTexture;
+        }
+
         public static Texture GetScreenshotTexture()
         {
             return m_renderSetup.RenderTargets[0];

--- a/Sources/VRage.Render/MyRender-Draw.cs
+++ b/Sources/VRage.Render/MyRender-Draw.cs
@@ -616,7 +616,7 @@ namespace VRageRender
         }
 
 
-        private static Texture RenderTextToTexture(MyRenderTextureId objectId, string text, float scale, Color fontColor, Color backgroundColor, int resolution, int aspectRatio)
+        private static Texture RenderTextToTexture(MyRenderTextureId objectId, string text, float scale, Color fontColor, Color backgroundColor, int resolution, int aspectRatio, int fontIndex)
         {
             if (m_screenshot != null)
             {
@@ -631,7 +631,7 @@ namespace VRageRender
                 MyRender.GraphicsDevice.Clear(ClearFlags.Target, new SharpDX.ColorBGRA(backgroundColor.R, backgroundColor.G, backgroundColor.B, 0), 1, 0);
                 MyRender.SetDeviceViewport(new SharpDX.Viewport(0, 0, surfaceDesc.Width, surfaceDesc.Height));
 
-                MyDebugDraw.DrawText(Vector2.Zero, new StringBuilder(text), fontColor, scale * MyRenderTexturePool.RenderQualityScale(), false, blendState:BlendState.EmissiveTexture);
+                MyDebugDraw.DrawText(Vector2.Zero, new StringBuilder(text), fontColor, scale * MyRenderTexturePool.RenderQualityScale(), false, blendState:BlendState.EmissiveTexture, fontIndex: fontIndex);
 
                 MyRender.SetRenderTarget(null, null);
             }

--- a/Sources/VRage.Render/MyRender-MessageSwitch.cs
+++ b/Sources/VRage.Render/MyRender-MessageSwitch.cs
@@ -901,7 +901,7 @@ namespace VRageRender
                             id.EntityId = rMessage.EntityId;
                             id.RenderObjectId = rMessage.RenderObjectID;
 
-                            material.DiffuseTexture = MyRender.RenderTextToTexture(id, rMessage.Text, rMessage.TextScale , rMessage.FontColor, rMessage.BackgroundColor, rMessage.TextureResolution, rMessage.TextureAspectRatio);
+                            material.DiffuseTexture = MyRender.RenderTextToTexture(id, rMessage.Text, rMessage.TextScale , rMessage.FontColor, rMessage.BackgroundColor, rMessage.TextureResolution, rMessage.TextureAspectRatio, rMessage.FontIndex);
                             if (material.DiffuseTexture == null)
                             {
                                 MyRenderProxy.TextNotDrawnToTexture(rMessage.EntityId);

--- a/Sources/VRage.Render/MyRender-MessageSwitch.cs
+++ b/Sources/VRage.Render/MyRender-MessageSwitch.cs
@@ -901,7 +901,7 @@ namespace VRageRender
                             id.EntityId = rMessage.EntityId;
                             id.RenderObjectId = rMessage.RenderObjectID;
 
-                            material.DiffuseTexture = MyRender.RenderTextToTexture(id, rMessage.Text, rMessage.TextScale , rMessage.FontColor, rMessage.BackgroundColor, rMessage.TextureResolution, rMessage.TextureAspectRatio, rMessage.FontIndex);
+                            material.DiffuseTexture = MyRender.RenderTextToTexture(id, rMessage.Text, rMessage.TextScale , rMessage.FontColor, rMessage.BackgroundColor, rMessage.TextureResolution, rMessage.TextureAspectRatio, rMessage.FontPath);
                             if (material.DiffuseTexture == null)
                             {
                                 MyRenderProxy.TextNotDrawnToTexture(rMessage.EntityId);

--- a/Sources/VRage.Render/MyRenderFont.cs
+++ b/Sources/VRage.Render/MyRenderFont.cs
@@ -19,13 +19,31 @@ namespace VRageRender
         {
         }
 
-        internal void LoadContent()
+        internal bool LoadContent()
         {
             foreach (var entry in m_bitmapInfoByID)
             {
                 var texture = MyTextureManager.GetTexture<MyTexture2D>(Path.Combine(m_fontDirectory, entry.Value.strFilename), "", null, LoadingMode.Immediate, TextureFlags.IgnoreQuality);
                 m_bitmapTextureById[entry.Key] = texture;
+
+                if (texture == null)
+                {
+                    UnloadContent();
+                    return false;
+                }
             }
+
+            return true;
+        }
+
+        internal void UnloadContent()
+        {
+            foreach (var entry in m_bitmapTextureById)
+            {
+                MyTextureManager.UnloadTexture(entry.Value);
+            }
+
+            m_bitmapTextureById.Clear();
         }
 
         /// <summary>

--- a/Sources/VRage.Render11/Primitives/MySpritesRenderer.cs
+++ b/Sources/VRage.Render11/Primitives/MySpritesRenderer.cs
@@ -313,9 +313,12 @@ namespace VRageRender
             //clipOffset += new Vector2(0.5f, -0.5f) * clipScale;
         }
 
-        internal static float DrawText(Vector2 screenCoord, StringBuilder text, VRageMath.Color color, float scale, MyGuiDrawAlignEnum align = MyGuiDrawAlignEnum.HORISONTAL_LEFT_AND_VERTICAL_TOP)
+        internal static float DrawText(Vector2 screenCoord, StringBuilder text, VRageMath.Color color, float scale, MyRenderFont font = null, MyGuiDrawAlignEnum align = MyGuiDrawAlignEnum.HORISONTAL_LEFT_AND_VERTICAL_TOP)
         {
-            var font = MyRender11.DebugFont;
+            if (font == null)
+            {
+                font = MyRender11.DebugFont;
+            }
 
             return font.DrawString(
                 MyUtils.GetCoordAligned(screenCoord, font.MeasureString(text, scale), align),

--- a/Sources/VRage.Render11/Render/MyRender-Content.cs
+++ b/Sources/VRage.Render11/Render/MyRender-Content.cs
@@ -7,7 +7,7 @@ using System.Text;
 using SharpDX;
 using SharpDX.Direct3D11;
 using SharpDX.DXGI;
-
+using VRage.Utils;
 using VRageMath;
 using VRageRender.Resources;
 using VRageRender.Vertex;
@@ -131,6 +131,12 @@ namespace VRageRender
 
             MyRender11.Log.WriteLine("Unloading session data");
 
+            foreach (var customFont in m_customFonts)
+            {
+                customFont.Value.UnloadContent();
+            }
+            m_customFonts.Clear();
+
             MyScene.RenderablesDBVH.Clear();
             MyScene.GroupsDBVH.Clear();
             MyClipmapFactory.RemoveAll();
@@ -166,6 +172,7 @@ namespace VRageRender
         #region Fonts
 
         static SortedDictionary<int, MyRenderFont> m_fontsById = new SortedDictionary<int, MyRenderFont>();
+        static Dictionary<string, MyRenderFont> m_customFonts = new Dictionary<string, MyRenderFont>();
         static MyRenderFont m_debugFont;
         internal static MyRenderFont DebugFont { get { return m_debugFont; } }
 
@@ -188,6 +195,17 @@ namespace VRageRender
         internal static MyRenderFont GetFont(int id)
         {
             return m_fontsById[id];
+        }
+        internal static MyRenderFont GetOrLoadCustomFont(string path)
+        {
+            MyRenderFont font;
+            if (!m_customFonts.TryGetValue(path, out font))
+            {
+                 font = new MyRenderFont(path);
+                 font.LoadContent();
+                 m_customFonts.Add(path, font);
+            }
+            return font;
         }
 
         #endregion

--- a/Sources/VRage.Render11/Render/MyRender-DebugMessages.cs
+++ b/Sources/VRage.Render11/Render/MyRender-DebugMessages.cs
@@ -268,7 +268,7 @@ namespace VRageRender
 
                             var text = new StringBuilder(message.Text);
 
-                            MySpritesRenderer.DrawText(message.Coord, text, message.Color, message.Scale, message.Align);
+                            MySpritesRenderer.DrawText(message.Coord, text, message.Color, message.Scale, MyRender11.DebugFont, message.Align);
 
                             break;
                         }
@@ -317,7 +317,7 @@ namespace VRageRender
                             if (clipPosition.Z > minDepth && clipPosition.Z < 1)
                             {
                                 MySpritesRenderer.DrawText(new Vector2(clipPosition.X, clipPosition.Y) * MyRender11.ViewportResolution,
-                                    new StringBuilder(message.Text), message.Color, message.Scale, message.Align);
+                                    new StringBuilder(message.Text), message.Color, message.Scale, MyRender11.DebugFont, message.Align);
                             }
 
                             break;

--- a/Sources/VRage.Render11/Render/MyRender-MessageSwitch.cs
+++ b/Sources/VRage.Render11/Render/MyRender-MessageSwitch.cs
@@ -677,6 +677,8 @@ namespace VRageRender
 
                         if (handle != RwTexId.NULL)
                         {
+                            var font = MyRender11.GetOrLoadCustomFont(rMessage.FontPath);
+
                             var clearColor = new SharpDX.Color4(rMessage.BackgroundColor.PackedValue);
                             clearColor.Alpha = 0;
                             MyRender11.ImmediateContext.ClearRenderTargetView(handle.Rtv, clearColor);
@@ -685,7 +687,7 @@ namespace VRageRender
                             MySpritesRenderer.PushState(new Vector2(rMessage.TextureResolution * rMessage.TextureAspectRatio, rMessage.TextureResolution));
 
 
-                            MySpritesRenderer.DrawText(Vector2.Zero, new StringBuilder(rMessage.Text), rMessage.FontColor, rMessage.TextScale);
+                            MySpritesRenderer.DrawText(Vector2.Zero, new StringBuilder(rMessage.Text), rMessage.FontColor, rMessage.TextScale, font);
                             // render text with fonts to rt
                             // update texture of proxy
                             MySpritesRenderer.Draw(handle.Rtv, new MyViewport(rMessage.TextureResolution * rMessage.TextureAspectRatio, rMessage.TextureResolution));

--- a/Sources/VRage.Render11/Render/Utils/MyDebugRenderer.cs
+++ b/Sources/VRage.Render11/Render/Utils/MyDebugRenderer.cs
@@ -347,7 +347,7 @@ namespace VRageRender
                     {
                         displayString.AppendFormat("{0}", ID);
                         MySpritesRenderer.DrawText(new Vector2(clipPosition.X, clipPosition.Y) * MyRender11.ViewportResolution,
-                            displayString, Color.DarkCyan, 0.5f);
+                            displayString, Color.DarkCyan, 0.5f, MyRender11.DebugFont);
                     }
 
                     displayString.Clear();

--- a/Sources/VRage.Render11/Render/Utils/MyRenderFont.cs
+++ b/Sources/VRage.Render11/Render/Utils/MyRenderFont.cs
@@ -28,6 +28,16 @@ namespace VRageRender
             }
         }
 
+        internal void UnloadContent()
+        {
+            foreach (var entry in m_bitmapTextureById)
+            {
+                MyTextures.UnloadResources(entry.Value);
+            }
+
+            m_bitmapTextureById.Clear();
+        }
+
         /// <summary>
         /// Draw the given string at vOrigin using the specified color
         /// </summary>

--- a/Sources/VRage.Render11/Render/Utils/MyRenderStats.cs
+++ b/Sources/VRage.Render11/Render/Utils/MyRenderStats.cs
@@ -53,7 +53,7 @@ namespace VRageRender
                         pos = new Vector2(MyRender11.ViewportResolution.X - m_rightColumnWidth, 0);
                     }
 
-                    MySpritesRenderer.DrawText(pos, m_tmpDrawText, color, scale);
+                    MySpritesRenderer.DrawText(pos, m_tmpDrawText, color, scale, MyRender11.DebugFont);
                 }
                 finally
                 {

--- a/Sources/VRage.Render11/Resources/Textures.cs
+++ b/Sources/VRage.Render11/Resources/Textures.cs
@@ -298,7 +298,7 @@ namespace VRageRender.Resources
             return NameIndex[nameKey];
         }
 
-        static void UnloadResources(TexId texId)
+        internal static void UnloadResources(TexId texId)
         {
             //Debug.Assert(CheckState(texId, MyTextureState.LOADED));
 

--- a/Sources/VRage/Render/Messages/MyRenderMessageDrawTextToMaterial.cs
+++ b/Sources/VRage/Render/Messages/MyRenderMessageDrawTextToMaterial.cs
@@ -17,6 +17,7 @@ namespace VRageRender
         public int TextureResolution;
         public int TextureAspectRatio;
         public long EntityId;
+        public int FontIndex;
 
         MyRenderMessageType IMyRenderMessage.MessageClass { get { return MyRenderMessageType.StateChangeOnce; } }
         MyRenderMessageEnum IMyRenderMessage.MessageType { get { return MyRenderMessageEnum.DrawTextToMaterial; } }

--- a/Sources/VRage/Render/Messages/MyRenderMessageDrawTextToMaterial.cs
+++ b/Sources/VRage/Render/Messages/MyRenderMessageDrawTextToMaterial.cs
@@ -17,7 +17,7 @@ namespace VRageRender
         public int TextureResolution;
         public int TextureAspectRatio;
         public long EntityId;
-        public int FontIndex;
+        public string FontPath;
 
         MyRenderMessageType IMyRenderMessage.MessageClass { get { return MyRenderMessageType.StateChangeOnce; } }
         MyRenderMessageEnum IMyRenderMessage.MessageType { get { return MyRenderMessageEnum.DrawTextToMaterial; } }

--- a/Sources/VRage/Render/MyRenderProxy.cs
+++ b/Sources/VRage/Render/MyRenderProxy.cs
@@ -1021,7 +1021,7 @@ namespace VRageRender
             message.EntityId = entityId;
             EnqueueMessage(message);
         }
-        public static void RenderTextToTexture(uint id, long entityId, string materialName, string text, float scale, Color fontColor, Color backgroundColor, int textureResolution, int textureAspectRatio)
+        public static void RenderTextToTexture(uint id, long entityId, string materialName, string text, float scale, Color fontColor, Color backgroundColor, int textureResolution, int textureAspectRatio, int fontIndex)
         {
             var message = MessagePool.Get<MyRenderMessageDrawTextToMaterial>(MyRenderMessageEnum.DrawTextToMaterial);
 
@@ -1034,6 +1034,7 @@ namespace VRageRender
             message.TextureAspectRatio = textureAspectRatio;
             message.BackgroundColor = backgroundColor;
             message.EntityId = entityId;
+            message.FontIndex = fontIndex;
             EnqueueMessage(message);
         }
         public static void TextNotDrawnToTexture(long entityID)

--- a/Sources/VRage/Render/MyRenderProxy.cs
+++ b/Sources/VRage/Render/MyRenderProxy.cs
@@ -1021,7 +1021,7 @@ namespace VRageRender
             message.EntityId = entityId;
             EnqueueMessage(message);
         }
-        public static void RenderTextToTexture(uint id, long entityId, string materialName, string text, float scale, Color fontColor, Color backgroundColor, int textureResolution, int textureAspectRatio, int fontIndex)
+        public static void RenderTextToTexture(uint id, long entityId, string materialName, string text, float scale, Color fontColor, Color backgroundColor, int textureResolution, int textureAspectRatio, string fontPath)
         {
             var message = MessagePool.Get<MyRenderMessageDrawTextToMaterial>(MyRenderMessageEnum.DrawTextToMaterial);
 
@@ -1034,7 +1034,7 @@ namespace VRageRender
             message.TextureAspectRatio = textureAspectRatio;
             message.BackgroundColor = backgroundColor;
             message.EntityId = entityId;
-            message.FontIndex = fontIndex;
+            message.FontPath = fontPath;
             EnqueueMessage(message);
         }
         public static void TextNotDrawnToTexture(long entityID)


### PR DESCRIPTION
As it had been discussed in issue #74, I've added support to load custom fonts for LCD screens from workshop mods.
An example of custom font mod can be found [here](https://github.com/kapitanov/SE_CustomFonts/tree/master/ModExample)
I've added `Font` property to `IMyTextPanel`, the corresponding GUI to select custom font and an API for PB and Scripts.

I should note that my implementation loads the fonts on demand in the render thread and might be not the best idea.

Also, custom fonts affect only LCDs, there's no code to apply them to any other ingame text, including GUI.