### PR TITLE
Ore position dictionary for ingame programming

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyOreDetector.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyOreDetector.cs
@@ -9,5 +9,6 @@ namespace Sandbox.ModAPI.Ingame
     {
         float Range {get;}
         bool BroadcastUsingAntennas {get;}
+        Dictionary<string, VRageMath.Vector3D> DetectedOres { get; }
     }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyOreDetector.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyOreDetector.cs
@@ -12,6 +12,7 @@ using VRageMath;
 using Sandbox.Game.Components;
 using Sandbox.ModAPI.Ingame;
 using Sandbox.Game.Localization;
+using System.Collections.Generic;
 
 #endregion
 
@@ -184,5 +185,6 @@ namespace Sandbox.Game.Entities.Cube
         }
         bool IMyOreDetector.BroadcastUsingAntennas { get { return m_oreDetectorComponent.BroadcastUsingAntennas; } }
         float IMyOreDetector.Range { get { return Range; } }
+        Dictionary<string, Vector3D> IMyOreDetector.DetectedOres { get { return m_oreDetectorComponent.detectedOres; } }
     }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyOreDetectorComponent.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyOreDetectorComponent.cs
@@ -191,6 +191,8 @@ namespace Sandbox.Game.Entities.Cube
 
         private readonly Dictionary<MyVoxelBase, MyOreDepositGroup> m_depositGroupsByEntity = new Dictionary<MyVoxelBase, MyOreDepositGroup>();
 
+        public Dictionary<string, Vector3D> detectedOres = new Dictionary<string, Vector3D>();
+
         public MyOreDetectorComponent()
         {
             DetectionRadius = 50;
@@ -203,6 +205,7 @@ namespace Sandbox.Game.Entities.Cube
         public void Update(Vector3D position, bool checkControl = true)
         {
             Clear();
+            detectedOres.Clear();
 
             if (!SetRelayedRequest && checkControl && !OnCheckControl())
             {
@@ -248,6 +251,16 @@ namespace Sandbox.Game.Entities.Cube
                 {
                     if (deposit != null)
                     {
+                        foreach(var ore in deposit.Materials)
+                        {
+                            string oreName = ore.Material.MinedOre;
+                            Vector3D orePosition;
+                            ore.ComputeWorldPosition(deposit.VoxelMap, out orePosition);
+                            if (!detectedOres.ContainsKey(oreName))
+                                detectedOres.Add(oreName, orePosition);
+                            else if (VRageMath.Vector3D.Distance(detectedOres[oreName], position) > VRageMath.Vector3D.Distance(orePosition, position))
+                                detectedOres[oreName] = orePosition;
+                        }
                         MyHud.OreMarkers.RegisterMarker(deposit);
                     }
                 }


### PR DESCRIPTION
Added a simple functionality to get the detected ores position as
Dictionary<string, Vector3D>. Thus each ore yields only the closest
position in any asteroid per OreDetector.

Example output from the below world and code:
http://i.imgur.com/Q2cGJrR.png

To test this feature use the workshop world:
http://steamcommunity.com/sharedfiles/filedetails/?id=445920958

or build a ship and use this example code ingame:

```C#
void Main(string args)
{
string output = "";
List<IMyTerminalBlock> blocks = new List<IMyTerminalBlock>();
GridTerminalSystem.GetBlocksOfType<IMyOreDetector>(blocks);
output += string.Format(">>> {0} OreDetectors\n", blocks.Count);
for(int i = 0; i < blocks.Count; i++)
{
IMyOreDetector oreDet = blocks[i] as IMyOreDetector;
output += string.Format("\n>> {0} ({1} ores)\n", oreDet.CustomName,
oreDet.DetectedOres.Count);
var enumerator = oreDet.DetectedOres.GetEnumerator();
while(enumerator.MoveNext())
{
var element = enumerator.Current;
output += string.Format("> {0}\n{1}\n", element.Key,
element.Value.ToString("{0.00}"));
}
}
Echo(output);
}
```