### PR TITLE
Added Height Offset for Suspension Wheels

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyMotorSuspension.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyMotorSuspension.cs
@@ -13,5 +13,6 @@ namespace Sandbox.ModAPI.Ingame
         float Strength { get;}
         float Friction { get;}
         float Power { get; }
+        float Height { get; }
     }
 }

--- a/Sources/Sandbox.Common/ObjectBuilders/Definitions/MyObjectBuilder_MotorSuspensionDefinition.cs
+++ b/Sources/Sandbox.Common/ObjectBuilders/Definitions/MyObjectBuilder_MotorSuspensionDefinition.cs
@@ -21,5 +21,11 @@ namespace Sandbox.Common.ObjectBuilders.Definitions
 
         [ProtoMember]
         public float SuspensionLimit = 0.1f;
+
+        [ProtoMember]
+        public float MinHeight = -0.32f;
+
+        [ProtoMember]
+        public float MaxHeight = 0.26f;
     }
 }

--- a/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_MotorSuspension.cs
+++ b/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_MotorSuspension.cs
@@ -31,5 +31,8 @@ namespace Sandbox.Common.ObjectBuilders
 
         [ProtoMember]
         public float Power = 1;
+
+        [ProtoMember]
+        public float Height = 0;
     }
 }

--- a/Sources/Sandbox.Game/Definitions/MyMotorSuspensionDefinition.cs
+++ b/Sources/Sandbox.Game/Definitions/MyMotorSuspensionDefinition.cs
@@ -14,6 +14,8 @@ namespace Sandbox.Definitions
         public float SteeringSpeed;
         public float PropulsionForce;
         public float SuspensionLimit;
+        public float MinHeight;
+        public float MaxHeight;
 
         protected override void Init(MyObjectBuilder_DefinitionBase builder)
         {
@@ -24,6 +26,8 @@ namespace Sandbox.Definitions
             SteeringSpeed = ob.SteeringSpeed;
             PropulsionForce = ob.PropulsionForce;
             SuspensionLimit = ob.SuspensionLimit;
+            MinHeight = ob.MinHeight;
+            MaxHeight = ob.MaxHeight;
         }
     }
 }

--- a/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
+++ b/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
@@ -6160,6 +6160,16 @@ namespace Sandbox.Game.Localization
         public static readonly MyStringId BlockPropertyTitle_Motor_Power = MyStringId.GetOrCompute("BlockPropertyTitle_Motor_Power");
 
         ///<summary>
+        ///Axle height offset from center
+        ///</summary>
+        public static readonly MyStringId BlockPropertyDescription_Motor_Height = MyStringId.GetOrCompute("BlockPropertyDescription_Motor_Height");
+
+        ///<summary>
+        ///Height Offset
+        ///</summary>
+        public static readonly MyStringId BlockPropertyTitle_Motor_Height = MyStringId.GetOrCompute("BlockPropertyTitle_Motor_Height");
+
+        ///<summary>
         ///Centered Window
         ///</summary>
         public static readonly MyStringId DisplayName_Block_VerticalCen = MyStringId.GetOrCompute("DisplayName_Block_VerticalCen");

--- a/Sources/Sandbox.Game/Game/Multiplayer/MySyncMotorSuspension.cs
+++ b/Sources/Sandbox.Game/Game/Multiplayer/MySyncMotorSuspension.cs
@@ -103,6 +103,19 @@ namespace Sandbox.Game.Multiplayer
             public float Steer;
         }
 
+        [MessageId(239, P2PMessageEnum.Reliable)]
+        struct HeightMsg : IEntityMessage
+        {
+            public long EntityId;
+
+            public long GetEntityId()
+            {
+                return EntityId;
+            }
+
+            public float Height;
+        }
+
         static MySyncMotorSuspension()
         {
             MySyncLayer.RegisterEntityMessage<MySyncMotorSuspension, SteeringMsg>(OnChangeControllable, MyMessagePermissions.Any);
@@ -112,6 +125,7 @@ namespace Sandbox.Game.Multiplayer
             MySyncLayer.RegisterEntityMessage<MySyncMotorSuspension, FrictionMsg>(OnChangeFriction, MyMessagePermissions.Any);
             MySyncLayer.RegisterEntityMessage<MySyncMotorSuspension, PowerMsg>(OnChangePower, MyMessagePermissions.Any);
             MySyncLayer.RegisterEntityMessage<MySyncMotorSuspension, SteerMsg>(OnUpdateSteer, MyMessagePermissions.Any);
+            MySyncLayer.RegisterEntityMessage<MySyncMotorSuspension, HeightMsg>(OnChangeHeight, MyMessagePermissions.Any);
         }
 
         public new MyMotorSuspension Entity
@@ -222,6 +236,20 @@ namespace Sandbox.Game.Multiplayer
         static void OnUpdateSteer(MySyncMotorSuspension sync, ref SteerMsg msg, MyNetworkClient sender)
         {
             sync.Entity.SteerAngle = msg.Steer;
+        }
+
+        internal void ChangeHeight(float v)
+        {
+            var msg = new HeightMsg();
+            msg.EntityId = Entity.EntityId;
+            msg.Height = v;
+
+            Sync.Layer.SendMessageToAllAndSelf(ref msg);
+        }
+
+        static void OnChangeHeight(MySyncMotorSuspension sync, ref HeightMsg msg, MyNetworkClient sender)
+        {
+            sync.Entity.Height = msg.Height;
         }
     }
 }

--- a/Sources/SpaceEngineers/Content/Data/CubeBlocks.sbc
+++ b/Sources/SpaceEngineers/Content/Data/CubeBlocks.sbc
@@ -18066,6 +18066,8 @@
       <MaxForceMagnitude>3.36E+07</MaxForceMagnitude>
       <RotorPart>RealWheel</RotorPart>
       <SuspensionLimit>0.7</SuspensionLimit>
+      <MinHeight>-1.5</MinHeight>
+      <MaxHeight>1.3</MaxHeight>
       <DamageEffectId>212</DamageEffectId>
     </Definition>
     <Definition xsi:type="MyObjectBuilder_MotorSuspensionDefinition">
@@ -18110,6 +18112,8 @@
       <MaxForceMagnitude>3.36E+07</MaxForceMagnitude>
       <RotorPart>RealWheel5x5</RotorPart>
       <SuspensionLimit>2.5</SuspensionLimit>
+      <MinHeight>-1.5</MinHeight>
+      <MaxHeight>1.3</MaxHeight>
       <DamageEffectId>212</DamageEffectId>
     </Definition>
     <Definition xsi:type="MyObjectBuilder_MotorSuspensionDefinition">
@@ -18156,6 +18160,8 @@
       <MaxForceMagnitude>3.36E+07</MaxForceMagnitude>
       <RotorPart>RealWheel1x1</RotorPart>
       <SuspensionLimit>0.6</SuspensionLimit>
+      <MinHeight>-1.5</MinHeight>
+      <MaxHeight>1.3</MaxHeight>
       <PropulsionForce>700</PropulsionForce>
       <DamageEffectId>212</DamageEffectId>
     </Definition>
@@ -18202,6 +18208,8 @@
       <RotorPart>RealWheel</RotorPart>
       <PropulsionForce>200</PropulsionForce>
       <SuspensionLimit>0.25</SuspensionLimit>
+      <MinHeight>-0.32</MinHeight>
+      <MaxHeight>0.26</MaxHeight>
       <DamageEffectId>212</DamageEffectId>
     </Definition>
     <Definition xsi:type="MyObjectBuilder_MotorSuspensionDefinition">
@@ -18245,6 +18253,8 @@
       <RotorPart>RealWheel5x5</RotorPart>
       <PropulsionForce>200</PropulsionForce>
       <SuspensionLimit>0.5</SuspensionLimit>
+      <MinHeight>-0.50</MinHeight>
+      <MaxHeight>0.35</MaxHeight>
       <DamageEffectId>212</DamageEffectId>
     </Definition>
     <Definition xsi:type="MyObjectBuilder_MotorSuspensionDefinition">
@@ -18289,6 +18299,8 @@
       <MaxForceMagnitude>3.36E+07</MaxForceMagnitude>
       <RotorPart>RealWheel1x1</RotorPart>
       <PropulsionForce>50</PropulsionForce>
+      <MinHeight>-0.32</MinHeight>
+      <MaxHeight>0.26</MaxHeight>
       <DamageEffectId>212</DamageEffectId>
     </Definition>
     <Definition>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
@@ -3875,6 +3875,12 @@ Respawn?</value>
   <data name="BlockPropertyTitle_Motor_Power" xml:space="preserve">
     <value>Power</value>
   </data>
+  <data name="BlockPropertyDescription_Motor_Height" xml:space="preserve">
+    <value>Axle height offset from center</value>
+  </data>
+  <data name="BlockPropertyTitle_Motor_Height" xml:space="preserve">
+    <value>Height Offset</value>
+  </data>
   <data name="DisplayName_Block_VerticalCen" xml:space="preserve">
     <value>Centered Window</value>
   </data>


### PR DESCRIPTION
Added a "Height Offset" option for MotorSuspension blocks which allows players to change the height of the wheel relative to its base, by default it's 0 which is in the middle, just like before.

This is useful for vehicles to travel better on very rough terrain having a bigger clearence under them and it can also be useful for racing vehicles that need a lower base.

Additionally MinHeight and MaxHeight parameters for cubeblocks to define the height slider range.

EDIT:
I plan on adding Max Steering Angle, Steer Speed, Steer Return Speed and Invert Steer Direction to the control panel as well but first I wanna see how this is received :}