### PR TITLE
Upgrade module effect values in block interface for assembler and reffinery

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyAssembler.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyAssembler.cs
@@ -5,8 +5,23 @@ using System.Text;
 
 namespace Sandbox.ModAPI.Ingame
 {
+    /// <summary>
+    /// Assembler block interface
+    /// </summary>
     public interface IMyAssembler : IMyProductionBlock
     {
+        /// <summary>
+        /// true - assembler in dissasemble mode, false - aseembler in normal mode
+        /// </summary>
         bool DisassembleEnabled { get; }
+
+        /// <summary>
+        /// Production speed - in decimals (0.5=50%)
+        /// </summary>
+        float Productivity { get; }
+        /// <summary>
+        /// Power efficiency - in decimals (0.5=50%)
+        /// </summary>
+        float PowerEfficiency { get; }
     }
 }

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyRefinery.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyRefinery.cs
@@ -5,7 +5,22 @@ using System.Text;
 
 namespace Sandbox.ModAPI.Ingame
 {
+    /// <summary>
+    /// Refinery block interface
+    /// </summary>
     public interface IMyRefinery : IMyProductionBlock
     {
+        /// <summary>
+        /// Ore conversion Effectiveness - in decimals (0.5=50%)
+        /// </summary>
+        float Effectiveness { get; }
+        /// <summary>
+        /// Production speed - in decimals (0.5=50%)
+        /// </summary>
+        float Productivity { get; }
+        /// <summary>
+        /// Power efficiency - in decimals (0.5=50%)
+        /// </summary>
+        float PowerEfficiency { get; }
     }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
@@ -1065,5 +1065,22 @@ namespace Sandbox.Game.Entities.Cube
         {
             return base.GetOperationalPowerConsumption() * (1f + UpgradeValues["Productivity"]) * (1f / UpgradeValues["PowerEfficiency"]);
         }
+
+        float IMyAssembler.Productivity
+        {
+            get
+            {
+                float evalue;
+                return UpgradeValues.TryGetValue("Productivity", out evalue) ? evalue : 1;
+            }
+        }
+        float IMyAssembler.PowerEfficiency
+        {
+            get
+            {
+                float evalue;
+                return UpgradeValues.TryGetValue("PowerEfficiency", out evalue) ? evalue : 1;
+            }
+        }
     }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyRefinery.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyRefinery.cs
@@ -312,5 +312,30 @@ namespace Sandbox.Game.Entities.Cube
         {
             return base.GetOperationalPowerConsumption() * (1f + UpgradeValues["Productivity"]) * (1f / UpgradeValues["PowerEfficiency"]);
         }
+
+        float IMyRefinery.Effectiveness
+        {
+            get
+            {
+                float evalue;
+                return UpgradeValues.TryGetValue("Effectiveness", out evalue) ? evalue : 1;
+            }
+        }
+        float IMyRefinery.Productivity
+        {
+            get
+            {
+                float evalue;
+                return UpgradeValues.TryGetValue("Productivity", out evalue) ? evalue : 1;
+            }
+        }
+        float IMyRefinery.PowerEfficiency
+        {
+            get
+            {
+                float evalue;
+                return UpgradeValues.TryGetValue("PowerEfficiency", out evalue) ? evalue : 1;
+            }
+        }
     }
 }


### PR DESCRIPTION
Direct field accessors for upgrade modules on affected blocks (refinery, assembler) for ingame scripting, so you can see for example productivity, without parsing it from detailed info.

might be usefull for example for task prioritization when using refinery/assembler management scripts.

