### PR TITLE
Changed power consumption to vary according to max range of sensor

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MySensorBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MySensorBlock.cs
@@ -678,7 +678,17 @@ namespace Sandbox.Game.Entities.Blocks
         protected float CalculateRequiredPowerInput()
         {
             if (Enabled && IsFunctional)
-                return 0.0003f * (float)Math.Pow((m_fieldMax - m_fieldMin).Volume, 1f / 3f);
+            {
+                float sensorVolume = (m_fieldMax - m_fieldMin).Volume;
+                float factor = (((float)Math.Floor(Math.Abs(m_fieldMax.X) / 50f + 0.5f) * 0.5f) / 10000f) +
+                               (((float)Math.Floor(Math.Abs(m_fieldMax.Y) / 50f + 0.5f) * 0.5f) / 10000f) +
+                               (((float)Math.Floor(Math.Abs(m_fieldMax.Z) / 50f + 0.5f) * 0.5f) / 10000f) +
+                               (((float)Math.Floor(Math.Abs(m_fieldMin.X) / 50f + 0.5f) * 0.5f) / 10000f) +
+                               (((float)Math.Floor(Math.Abs(m_fieldMin.Y) / 50f + 0.5f) * 0.5f) / 10000f) +
+                               (((float)Math.Floor(Math.Abs(m_fieldMin.Z) / 50f + 0.5f) * 0.5f) / 10000f);
+
+               return factor * (float)Math.Pow(sensorVolume, 1f / 3f);
+            }
             else
                 return 0.0f;
         }

--- a/Sources/Sandbox.Game/Game/Screens/Helpers/MyToolbar.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Helpers/MyToolbar.cs
@@ -40,10 +40,10 @@ namespace Sandbox.Game.Screens.Helpers
         }
 
         public const int DEF_SLOT_COUNT = 9;
-        public const int DEF_PAGE_COUNT = 4;
+        public const int DEF_PAGE_COUNT = 9;
 
         public int SlotCount = 9;
-        public int PageCount = 4;
+        public int PageCount = 9;
         public int ItemCount { get { return SlotCount * PageCount; } }
 
         private MyToolbarItem[] m_items;


### PR DESCRIPTION
This change increases the power consumed by the sensor based on the range being used.

With vanilla max of 50m, nothing changes.

With every increment of 50m that you set any of the extents, above the vanilla 50m max, power consumption increases.

Example: with all extents set to 50m, power consumption doesn't change.

If you were to increase the maxrange to 100m, AND set the extents all to 100m, then power consumption would be double that of the vanilla max of 50m. If you set all the extents to 50m (even when maxrange is set to 100m) power consumption is the same as vanilla 50m max.

In other words, it increases power consumption on range USED. So regardless of where the max range is set, power consumption only increases as you actually set the extents above the norm.

Also increased number of toolbars to 9, since that seems to be a popular request among players.