### PR TITLE
Add an Installer class to the SE.Dedicated assembly

### DIFF
--- a/Sources/SpaceEngineers.Dedicated/ServiceInstaller.cs
+++ b/Sources/SpaceEngineers.Dedicated/ServiceInstaller.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using VRage.Dedicated;
+
+namespace SpaceEngineersDedicated
+{
+    /// <summary>
+    /// ServiceInstaller provides a public Installer for the SE dedicated server assembly.
+    /// This enables it to be installed as a Windows service.
+    /// </summary>
+    public class ServiceInstaller : WindowsServiceInstaller
+    {
+    }
+}

--- a/Sources/SpaceEngineers.Dedicated/SpaceEngineers.Dedicated.csproj
+++ b/Sources/SpaceEngineers.Dedicated/SpaceEngineers.Dedicated.csproj
@@ -163,6 +163,9 @@
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
     </Compile>
+    <Compile Include="ServiceInstaller.cs">
+      <SubType>Component</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Content Include="GameThumbnail.png" />


### PR DESCRIPTION
Fixes #129

InstallUtil searches the assembly being installed for a public Installer
class, in order to install the service. This derived class makes the
functionality of VRage.Dedicated.WindowsServiceInstaller available
within the dedicated server assembly, so it can be installed.