### PR TITLE
Color picker fixes.

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBuilder.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBuilder.cs
@@ -1586,7 +1586,7 @@ namespace Sandbox.Game.Entities
                     foreach (var gizmoSpace in m_gizmo.Spaces)
                     {
                         if (gizmoSpace.m_removeBlock != null)
-                            MyToolbar.ColorMaskHSV = gizmoSpace.m_removeBlock.ColorMaskHSV;
+                            MyToolbar.AddOrSwitchToColor(gizmoSpace.m_removeBlock.ColorMaskHSV);
                     }
                 }
             }

--- a/Sources/Sandbox.Game/Game/Screens/Helpers/MyToolbar.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Helpers/MyToolbar.cs
@@ -87,6 +87,14 @@ namespace Sandbox.Game.Screens.Helpers
             }
         }
 
+        public static int ColorMaskSlotCount
+        {
+            get
+            {
+                return m_colorMaskSlotCount;
+            }
+        }
+
         public bool ShowHolsterSlot
         {
             get { return m_toolbarType == MyToolbarType.Character; }
@@ -296,8 +304,20 @@ namespace Sandbox.Game.Screens.Helpers
             m_colorMaskHSVSlots[5] = (MyRenderComponentBase.OldWhiteToHSV);
             m_colorMaskHSVSlots[6] = (MyRenderComponentBase.OldBlackToHSV);
             for (int i = 7; i < m_colorMaskSlotCount; i++)
-                if (m_colorMaskHSVSlots[i] == MyRenderComponentBase.OldBlackToHSV)
-                    m_colorMaskHSVSlots[i] = (m_colorMaskHSVSlots[i - 7] + new Vector3(0, 0.15f, 0.2f));
+                m_colorMaskHSVSlots[i] = (m_colorMaskHSVSlots[i - 7] + new Vector3(0, 0.15f, 0.2f));
+        }
+
+        public static void AddOrSwitchToColor(Vector3 color)
+        {
+            for (int i = 0; i < m_colorMaskSlotCount; i++)
+            {
+                if (m_colorMaskHSVSlots[i] == color)
+                {
+                    m_currentColorMaskHSV = i;
+                    return;
+                }
+            }
+            ColorMaskHSV = color;
         }
 
         public MyObjectBuilder_Toolbar GetObjectBuilder()

--- a/Sources/Sandbox.Game/Game/Screens/MyGuiScreenColorPicker.cs
+++ b/Sources/Sandbox.Game/Game/Screens/MyGuiScreenColorPicker.cs
@@ -236,7 +236,7 @@ namespace Sandbox.Game.Gui
         {
             MyToolbar.SetDefaultColors();
             Color c = Color.White;
-            for (int i = 0; i < 7; i++)
+            for (int i = 0; i < MyToolbar.ColorMaskSlotCount; i++)
                 m_colorPaletteControlsList[i].ColorMask = (prev(MyToolbar.m_colorMaskHSVSlots[i])).HSVtoColor().ToVector4();
             UpdateSliders(MyToolbar.ColorMaskHSV);
         }


### PR DESCRIPTION
* Fix returning to default colors (the bottom row didn't change).
* When you select a color from a block with shift-P, if that color is already in the palette, switch to it rather than overwriting the current color.