### PR TITLE
Fix Drill Invisible Wall

### DIFF
--- a/Sources/Sandbox.Game/Game/Weapons/Guns/MyShipDrill.cs
+++ b/Sources/Sandbox.Game/Game/Weapons/Guns/MyShipDrill.cs
@@ -211,7 +211,7 @@ namespace Sandbox.Game.Weapons
         private void SetupDrillFrameCountdown()
         {
             m_countdownDistributor += 10;
-            if (m_countdownDistributor > MyDrillConstants.DRILL_UPDATE_DISTRIBUTION_IN_FRAMES)
+            if (m_countdownDistributor >= MyDrillConstants.DRILL_UPDATE_DISTRIBUTION_IN_FRAMES)
                 m_countdownDistributor = -MyDrillConstants.DRILL_UPDATE_DISTRIBUTION_IN_FRAMES;
             m_drillFrameCountdown = MyDrillConstants.DRILL_UPDATE_INTERVAL_IN_FRAMES + m_countdownDistributor;
         }


### PR DESCRIPTION
Fix drills hitting invisible wall when mining

I can't explain how it works in detail. But a large drilling ship starting at 2 m/s to drill did not bump at once into the invisible wall. Speed drops very slowly to 1 m/s where it stays without a problem.