### PR TITLE
Enable hiding of terminal interaction dummies.

### DIFF
--- a/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_TerminalBlock.cs
+++ b/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_TerminalBlock.cs
@@ -19,5 +19,8 @@ namespace Sandbox.Common.ObjectBuilders
 
         [ProtoMember]
         public bool ShowInTerminal = true;
+
+        [ProtoMember]
+        public bool ShowTerminalAccess = true;
     }
 }

--- a/Sources/Sandbox.Game/Engine/Utils/MyConstants.cs
+++ b/Sources/Sandbox.Game/Engine/Utils/MyConstants.cs
@@ -505,4 +505,17 @@ namespace Sandbox.Engine.Utils
     {
         public const float OXYGEN_REGEN_PER_SECOND = 2000f;
     }
+
+    static class MyDummyNameConstants
+    {
+        public const string BLOCK = "block";
+        public const string COCKPIT = "cockpit";
+        public const string CONVEYOR = "conveyor";
+        public const string CRYOPOD = "cryopod";
+        public const string INVENTORY = "inventory";
+        public const string PANEL = "panel";
+        public const string TERMINAL = "terminal";
+        public const string TEXTPANEL = "textpanel";
+        public const string WARDROBE = "wardrobe";
+    }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBlock.cs
@@ -576,6 +576,24 @@ namespace Sandbox.Game.Entities
                         if (parts.Length < 2)
                             continue;
 
+                        if (this is MyTerminalBlock && !(this as MyTerminalBlock).ShowTerminalAccess)
+                        {
+                            switch (parts[1])
+                            {
+                                    // Don't block access to "conveyor"
+                                    // Even though reactors and cargo allow terminal access through them,
+                                    // removing them will remove conveyor access as well
+                                case MyDummyNameConstants.TERMINAL:    // Most terminal blocks
+                                case MyDummyNameConstants.TEXTPANEL:   // LCD/Text Panel
+                                case MyDummyNameConstants.INVENTORY:   // non-conveyor inventory access
+                                case MyDummyNameConstants.COCKPIT:     // Seats
+                                case MyDummyNameConstants.BLOCK:       // Healing station of med room (wardrobe doesn't have terminal access)
+                                case MyDummyNameConstants.CRYOPOD:     // similar access as cockpit
+                                    continue;
+                            }
+                         
+                        }
+
                         var dummyData = dummy.Value;
                         List<Matrix> matrices;
                         if (!m_detectors.TryGetValue(parts[1], out matrices))

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyTerminalBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyTerminalBlock.cs
@@ -39,10 +39,16 @@ namespace Sandbox.Game.Entities.Cube
             onOffSwitch.Getter = (x) => x.ShowOnHUD;
             onOffSwitch.Setter = (x, v) => x.RequestShowOnHUD(v);
             MyTerminalControlFactory.AddControl(onOffSwitch);
+
+            var showTerminal = new MyTerminalControlOnOffSwitch<MyTerminalBlock>("ShowTerminalAccess", MySpaceTexts.Terminal_ShowTerminalAccess, MySpaceTexts.Terminal_ShowTerminalAccessToolTip);
+            showTerminal.Getter = (x) => x.m_showTerminalAccess;
+            showTerminal.Setter = (x, v) => x.RequestShowTerminalAccess(v);
+            MyTerminalControlFactory.AddControl(showTerminal);
         }
 
         private bool m_showOnHUD;
         private bool m_showInTerminal;
+        private bool m_showTerminalAccess;
 
         /// <summary>
         /// Name in terminal
@@ -76,6 +82,21 @@ namespace Sandbox.Game.Entities.Cube
                 }
             }
         }
+
+        public bool ShowTerminalAccess
+        {
+            get { return m_showTerminalAccess; }
+            set
+            {
+                if (m_showTerminalAccess != value)
+                {
+                    m_showTerminalAccess = value;
+                    ReloadDetectors();
+                    RaiseShowTerminalAccessChanged();
+                }
+            }
+        }
+
         public bool IsAccessibleForProgrammableBlock = true;
 
         public void RequestShowOnHUD(bool enable)
@@ -86,6 +107,11 @@ namespace Sandbox.Game.Entities.Cube
         public void RequestShowInTerminal(bool enable)
         {
             MySyncBlockHelpers.SendShowInTerminalRequest(this, enable);
+        }
+
+        public void RequestShowTerminalAccess(bool enable)
+        {
+            MySyncBlockHelpers.SendShowTerminalAccessRequest(this, enable);
         }
 
         /// <summary>
@@ -99,6 +125,7 @@ namespace Sandbox.Game.Entities.Cube
         public event Action<MyTerminalBlock> VisibilityChanged;
         public event Action<MyTerminalBlock> ShowOnHUDChanged;
         public event Action<MyTerminalBlock> ShowInTerminalChanged;
+        public event Action<MyTerminalBlock> ShowTerminalAccessChanged;
 
         public MyTerminalBlock()
         {
@@ -125,6 +152,7 @@ namespace Sandbox.Game.Entities.Cube
 
             ShowOnHUD = ob.ShowOnHUD;
             ShowInTerminal = ob.ShowInTerminal;
+            ShowTerminalAccess = ob.ShowTerminalAccess;
             AddDebugRenderComponent(new MyDebugRenderComponentTerminal(this));
         }
 
@@ -134,6 +162,7 @@ namespace Sandbox.Game.Entities.Cube
             ob.CustomName = (DisplayNameText.CompareTo(BlockDefinition.DisplayNameText) != 0) ? DisplayNameText.ToString() : null;
             ob.ShowOnHUD = ShowOnHUD;
             ob.ShowInTerminal = ShowInTerminal;
+            ob.ShowTerminalAccess = ShowTerminalAccess;
             return ob;
         }
 
@@ -204,6 +233,12 @@ namespace Sandbox.Game.Entities.Cube
         protected void RaiseShowInTerminalChanged()
         {
             var handler = ShowInTerminalChanged;
+            if (handler != null) handler(this);
+        }
+
+        protected void RaiseShowTerminalAccessChanged()
+        {
+            var handler = ShowTerminalAccessChanged;
             if (handler != null) handler(this);
         }
 

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectCockpitDoor.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectCockpitDoor.cs
@@ -10,7 +10,7 @@ using VRageMath;
 
 namespace Sandbox.Game.Entities.Cube
 {
-    [MyUseObject("cockpit")]
+    [MyUseObject(MyDummyNameConstants.COCKPIT)]
     class MyUseObjectCockpitDoor : IMyUseObject
     {
         public readonly MyCubeBlock Cockpit;

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectCryoChamberDoor.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectCryoChamberDoor.cs
@@ -15,7 +15,7 @@ using VRageMath;
 
 namespace Sandbox.Game.Entities.Cube
 {
-    [MyUseObject("cryopod")]
+    [MyUseObject(MyDummyNameConstants.CRYOPOD)]
     class MyUseObjectCryoChamberDoor : IMyUseObject
     {
         public readonly MyCryoChamber CryoChamber;

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectInventory.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectInventory.cs
@@ -10,8 +10,8 @@ using VRageMath;
 
 namespace Sandbox.Game.Entities.Cube
 {
-    [MyUseObject("inventory")]
-    [MyUseObject("conveyor")]
+    [MyUseObject(MyDummyNameConstants.INVENTORY)]
+    [MyUseObject(MyDummyNameConstants.CONVEYOR)]
     class MyUseObjectInventory : IMyUseObject
     {
         public readonly MyCubeBlock Block;

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectMedicalRoom.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectMedicalRoom.cs
@@ -9,7 +9,7 @@ using VRageMath;
 
 namespace Sandbox.Game.Entities.Cube
 {
-    [MyUseObject("block")]
+    [MyUseObject(MyDummyNameConstants.BLOCK)]
     class MyUseObjectMedicalRoom : IMyUseObject
     {
         private MyMedicalRoom m_medicalRoom;

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectPanelButton.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectPanelButton.cs
@@ -16,7 +16,7 @@ using VRageMath;
 
 namespace Sandbox.Game.Entities.Cube
 {
-    [MyUseObject("panel")]
+    [MyUseObject(MyDummyNameConstants.PANEL)]
     class MyUseObjectPanelButton : IMyUseObject
     {
         private readonly MyButtonPanel m_buttonPanel;

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectTerminal.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectTerminal.cs
@@ -10,7 +10,7 @@ using VRageMath;
 
 namespace Sandbox.Game.Entities.Cube
 {
-    [MyUseObject("terminal")]
+    [MyUseObject(MyDummyNameConstants.TERMINAL)]
     class MyUseObjectTerminal : IMyUseObject
     {
         public readonly MyCubeBlock Block;

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectTextPanel.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectTextPanel.cs
@@ -11,7 +11,7 @@ using VRageMath;
 
 namespace Sandbox.Game.Entities.Cube
 {
-    [MyUseObject("textpanel")]
+    [MyUseObject(MyDummyNameConstants.TEXTPANEL)]
     class MyUseObjectTextPanel : IMyUseObject
     {
         private MyTextPanel m_textPanel;

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectWardrobe.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectWardrobe.cs
@@ -12,7 +12,7 @@ using VRageMath;
 
 namespace Sandbox.Game.Entities.Cube
 {
-    [MyUseObject("wardrobe")]
+    [MyUseObject(MyDummyNameConstants.WARDROBE)]
     class MyUseObjectWardrobe : IMyUseObject
     {
         public readonly MyCubeBlock Block;

--- a/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
+++ b/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
@@ -10328,5 +10328,15 @@ namespace Sandbox.Game.Localization
         ///Changing the renderer requires restart of the game.
         ///</summary>
         public static readonly MyStringId ToolTipVideoOptionsRenderer = MyStringId.GetOrCompute("ToolTipVideoOptionsRenderer");
+
+        ///<summary>
+        ///Show exterior terminal access
+        ///</summary>
+        public static readonly MyStringId Terminal_ShowTerminalAccess = MyStringId.GetOrCompute("Terminal_ShowTerminalAccess");
+
+        ///<summary>
+        ///Show/hide current block's exterior terminal access ports
+        ///</summary>
+        public static readonly MyStringId Terminal_ShowTerminalAccessToolTip = MyStringId.GetOrCompute("Terminal_ShowTerminalAccessToolTip");
     }
 }

--- a/Sources/Sandbox.Game/Game/Multiplayer/MySyncBlockHelpers.cs
+++ b/Sources/Sandbox.Game/Game/Multiplayer/MySyncBlockHelpers.cs
@@ -76,6 +76,22 @@ namespace Sandbox.Game.Multiplayer
             }
         }
 
+        [MessageId(15274, P2PMessageEnum.Reliable)]
+        struct ShowTerminalAccessMsg : IEntityMessage
+        {
+            public long EntityId;
+
+            public long GetEntityId() { return EntityId; }
+
+            public BoolBlit Show;
+
+            public override string ToString()
+            {
+                return String.Format("{0}, {1}", this.GetType().Name, this.GetEntityText());
+            }
+        }
+
+
         static MySyncBlockHelpers()
         {
             MySyncLayer.RegisterMessage<EnableMsg>(EnableRequest, MyMessagePermissions.ToServer, MyTransportMessageEnum.Request);
@@ -90,6 +106,8 @@ namespace Sandbox.Game.Multiplayer
             MySyncLayer.RegisterMessage<ShowInTerminalMsg>(ShowInTerminalRequest, MyMessagePermissions.ToServer, MyTransportMessageEnum.Request);
             MySyncLayer.RegisterMessage<ShowInTerminalMsg>(ShowInTerminalSuccess, MyMessagePermissions.FromServer, MyTransportMessageEnum.Success);
 
+            MySyncLayer.RegisterMessage<ShowTerminalAccessMsg>(ShowTerminalAccessRequest, MyMessagePermissions.ToServer, MyTransportMessageEnum.Request);
+            MySyncLayer.RegisterMessage<ShowTerminalAccessMsg>(ShowTerminalAccessSuccess, MyMessagePermissions.FromServer, MyTransportMessageEnum.Success);
         }
 
         static bool GetBlock<T>(long entityId, out T block)
@@ -214,6 +232,15 @@ namespace Sandbox.Game.Multiplayer
             Sync.Layer.SendMessageToServer(ref msg, MyTransportMessageEnum.Request);
         }
 
+        public static void SendShowTerminalAccessRequest(MyTerminalBlock block, bool show)
+        {
+            var msg = new ShowTerminalAccessMsg();
+            msg.EntityId = block.EntityId;
+            msg.Show = show;
+
+            Sync.Layer.SendMessageToServer(ref msg, MyTransportMessageEnum.Request);
+        }
+
         static void ShowInTerminalRequest(ref ShowInTerminalMsg msg, MyNetworkClient sender)
         {
             MyTerminalBlock block;
@@ -229,6 +256,24 @@ namespace Sandbox.Game.Multiplayer
             if (GetBlock(msg.EntityId, out block))
             {
                 block.ShowInTerminal = msg.Show;
+            }
+        }
+
+        static void ShowTerminalAccessRequest(ref ShowTerminalAccessMsg msg, MyNetworkClient sender)
+        {
+            MyTerminalBlock block;
+            if (GetBlock(msg.EntityId, out block))
+            {
+                Sync.Layer.SendMessageToAllAndSelf(ref msg, MyTransportMessageEnum.Success);
+            }
+        }
+
+        static void ShowTerminalAccessSuccess(ref ShowTerminalAccessMsg msg, MyNetworkClient sender)
+        {
+            MyTerminalBlock block;
+            if (GetBlock(msg.EntityId, out block))
+            {
+                block.ShowTerminalAccess = msg.Show;
             }
         }
     }

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
@@ -6396,4 +6396,10 @@ To connect to lasers not listed here you can connect to coordinates.</value>
   <data name="ToolTipVideoOptionsRenderer" xml:space="preserve">
     <value>Changing the renderer requires restart of the game.</value>
   </data>
+  <data name="Terminal_ShowTerminalAccess" xml:space="preserve">
+    <value>Show exterior terminal access</value>
+  </data>
+  <data name="Terminal_ShowTerminalAccessToolTip" xml:space="preserve">
+    <value>Show/hide current block's exterior terminal access ports</value>
+  </data>
 </root>


### PR DESCRIPTION
This change adds a UI button to toggle exterior terminal access for various blocks.
It does this by removing the terminal dummies you interact with.

I wrote this to be an extension of the 'Show In Terminal' feature.
It also doubles as a way for Text/LCD panels to show a display, while not having the yellow dummy covering the entire display when looking at it.

This is a re-request of #54 with generated file left in and synced to latest master.