### PR TITLE
Floating item quantity display update

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/MyFloatingObject.cs
+++ b/Sources/Sandbox.Game/Game/Entities/MyFloatingObject.cs
@@ -265,6 +265,7 @@ namespace Sandbox.Game.Entities
                     MyAudio.Static.PlaySound(TAKE_ITEM_SOUND.SoundId);
                 //user.StartSecondarySound(TAKE_ITEM_SOUND);
                 user.GetInventory().TakeFloatingObject(this);
+                MyHud.Notifications.ReloadTexts();
             }
         }
 
@@ -282,6 +283,7 @@ namespace Sandbox.Game.Entities
         MyActionDescription IMyUseObject.GetActionInfo(UseActionEnum actionEnum)
         {
             var key = MyInput.Static.GetGameControl(MyControlsSpace.USE).GetControlButtonName(MyGuiInputDeviceEnum.Keyboard);
+            //UpdateDisplay();
             return new MyActionDescription()
             {
                 Text = MySpaceTexts.NotificationPickupObject,

--- a/Sources/Sandbox.Game/Game/Entities/MyFloatingObject.cs
+++ b/Sources/Sandbox.Game/Game/Entities/MyFloatingObject.cs
@@ -265,7 +265,6 @@ namespace Sandbox.Game.Entities
                     MyAudio.Static.PlaySound(TAKE_ITEM_SOUND.SoundId);
                 //user.StartSecondarySound(TAKE_ITEM_SOUND);
                 user.GetInventory().TakeFloatingObject(this);
-                MyHud.Notifications.ReloadTexts();
             }
         }
 
@@ -283,7 +282,6 @@ namespace Sandbox.Game.Entities
         MyActionDescription IMyUseObject.GetActionInfo(UseActionEnum actionEnum)
         {
             var key = MyInput.Static.GetGameControl(MyControlsSpace.USE).GetControlButtonName(MyGuiInputDeviceEnum.Keyboard);
-            //UpdateDisplay();
             return new MyActionDescription()
             {
                 Text = MySpaceTexts.NotificationPickupObject,

--- a/Sources/Sandbox.Game/Game/Entities/MyFloatingObject.cs
+++ b/Sources/Sandbox.Game/Game/Entities/MyFloatingObject.cs
@@ -265,6 +265,7 @@ namespace Sandbox.Game.Entities
                     MyAudio.Static.PlaySound(TAKE_ITEM_SOUND.SoundId);
                 //user.StartSecondarySound(TAKE_ITEM_SOUND);
                 user.GetInventory().TakeFloatingObject(this);
+                MyHud.Notifications.ReloadTexts();
             }
         }
 


### PR DESCRIPTION
The quantity of a floating item didn't update if a player took a partial amount. I added a call to MyHud.Notifications.ReloadTexts() right after the item is added to the player's inventory. Previously the amount displayed didn't update until the player looked away and then back at the object, but it now updates immediately after picking it up.