### PR TITLE
Dynamic notification for the API

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/IMyHudNotification.cs
+++ b/Sources/Sandbox.Common/ModAPI/IMyHudNotification.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Sandbox.Common;
+
+namespace Sandbox.ModAPI
+{
+    public interface IMyHudNotification
+    {
+        /// <summary>
+        /// Get or set the notification text.
+        /// Setting the text will immediatly update it if the notification is shown.
+        /// </summary>
+        string Text { get; set; }
+
+        /// <summary>
+        /// Get or set the font for this notification.
+        /// Setting it will immediatly update it if the notification is shown.
+        /// </summary>
+        MyFontEnum Font { get; set;  }
+
+        /// <summary>
+        /// Get or set the time for the notification to be shown, in miliseconds.
+        /// </summary>
+        int AliveTime { get; set; }
+
+        /// <summary>
+        /// Shows the notification on the HUD.
+        /// </summary>
+        void Show();
+
+        /// <summary>
+        /// Hides the notification on the HUD even if it was supposed to show for longer.
+        /// </summary>
+        void Hide();
+
+        /// <summary>
+        /// Reset the alive time for the text.
+        /// This is called when setting AliveTime as well.
+        /// </summary>
+        void ResetAliveTime();
+    }
+}

--- a/Sources/Sandbox.Common/ModAPI/IMyUtilities.cs
+++ b/Sources/Sandbox.Common/ModAPI/IMyUtilities.cs
@@ -17,6 +17,18 @@ namespace Sandbox.ModAPI
         IMyConfigDedicated ConfigDedicated { get; }
         string GetTypeName(Type type);
         void ShowNotification(string message, int disappearTimeMs = 2000, Common.MyFontEnum font = Common.MyFontEnum.White);
+
+        /// <summary>
+        /// Create a notification object.
+        /// The object needs to have Show() called on it to be shown.
+        /// On top of that you can dynamically change the text, font and adjust the time to live.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="disappearTimeMs"></param>
+        /// <param name="font"></param>
+        /// <returns>The notification object.</returns>
+        IMyHudNotification CreateNotification(string message, int disappearTimeMs = 2000, Common.MyFontEnum font = Common.MyFontEnum.White);
+
         void ShowMessage(string sender, string messageText);
         void SendMessage(string messageText);
         event MessageEnteredDel MessageEntered;

--- a/Sources/Sandbox.Common/Sandbox.Common.csproj
+++ b/Sources/Sandbox.Common/Sandbox.Common.csproj
@@ -237,6 +237,7 @@
     <Compile Include="ModAPI\Ingame\PistonStatus.cs" />
     <Compile Include="ModAPI\Ingame\MyGridProgram.cs" />
     <Compile Include="ModAPI\Ingame\TerminalActionParameter.cs" />
+    <Compile Include="ModAPI\IMyHudNotification.cs" />
     <Compile Include="ModAPI\Interfaces\IMyDestroyableObject.cs" />
     <Compile Include="ModAPI\IMyIdentity.cs" />
     <Compile Include="ModAPI\Interfaces\IMyInventoryOwner.cs" />

--- a/Sources/Sandbox.Game/Game/GUI/MyHudNotification.cs
+++ b/Sources/Sandbox.Game/Game/GUI/MyHudNotification.cs
@@ -6,6 +6,7 @@ using Sandbox.Engine.Utils;
 using Sandbox.Graphics.GUI;
 
 using Sandbox.Common;
+using Sandbox.ModAPI;
 using VRage;
 using Sandbox.Definitions;
 using Sandbox.Graphics;
@@ -33,10 +34,11 @@ namespace Sandbox.Game.Gui
         private object[] m_textFormatArguments = new object[20];
         private MyGuiDrawAlignEnum m_actualTextAlign;
         private int m_aliveTime;
-        private int m_lifespanMs;
         private string m_notificationText;
         private bool m_isTextDirty;
         #endregion
+
+        public int m_lifespanMs;
 
         public MyNotificationLevel Level = MyNotificationLevel.Normal;
 
@@ -44,7 +46,7 @@ namespace Sandbox.Game.Gui
 
         public readonly int Priority;
 
-        public readonly MyFontEnum Font;
+        public MyFontEnum Font;
 
         public bool Alive
         {
@@ -155,7 +157,7 @@ namespace Sandbox.Game.Gui
         { }
     }
 
-    public class MyHudNotification : MyHudNotificationBase
+    public partial class MyHudNotification : MyHudNotificationBase
     {
         private MyStringId m_originalText;
        

--- a/Sources/Sandbox.Game/ModAPI/MyAPIUtilities_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/MyAPIUtilities_ModAPI.cs
@@ -42,6 +42,13 @@ namespace Sandbox.ModAPI
             MyHud.Notifications.Add(not);
         }
 
+        IMyHudNotification IMyUtilities.CreateNotification(string message, int disappearTimeMs, Common.MyFontEnum font)
+        {
+            var notification = new MyHudNotification(MySpaceTexts.CustomText, disappearTimeMs, font);
+            notification.SetTextFormatArguments(message);
+            return notification as IMyHudNotification;
+        }
+
         void IMyUtilities.ShowMessage(string sender, string messageText)
         {
             MyHud.Chat.ShowMessage(sender, messageText);

--- a/Sources/Sandbox.Game/ModAPI/MyHudNotification_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/MyHudNotification_ModAPI.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Sandbox.Common;
+using Sandbox.ModAPI;
+
+namespace Sandbox.Game.Gui
+{
+    public partial class MyHudNotification : IMyHudNotification
+    {
+        string IMyHudNotification.Text
+        {
+            get { return this.GetText(); }
+            set { SetTextFormatArguments(value); }
+        }
+
+        int IMyHudNotification.AliveTime
+        {
+            get { return this.m_lifespanMs; }
+            set
+            {
+                m_lifespanMs = value;
+                ResetAliveTime();
+            }
+        }
+
+        MyFontEnum IMyHudNotification.Font
+        {
+            get { return Font; }
+            set { Font = value; }
+        }
+
+        void IMyHudNotification.Show()
+        {
+            MyHud.Notifications.Add(this);
+        }
+
+        void IMyHudNotification.Hide()
+        {
+            MyHud.Notifications.Remove(this);
+        }
+
+        void IMyHudNotification.ResetAliveTime()
+        {
+            this.ResetAliveTime();
+        }
+    }
+}

--- a/Sources/Sandbox.Game/Sandbox.Game.csproj
+++ b/Sources/Sandbox.Game/Sandbox.Game.csproj
@@ -718,6 +718,7 @@
     <Compile Include="Game\World\Triggers\MyTriggerSomeoneWon.cs" />
     <Compile Include="ModAPI\Blocks\MyTextPanel_ModAPI.cs" />
     <Compile Include="ModAPI\MyMotorSuspension_ModAPI.cs" />
+    <Compile Include="ModAPI\MyHudNotification_ModAPI.cs" />
     <Compile Include="ModAPI\MyBlockGroup_ModAPI.cs" />
     <Compile Include="ModAPI\MyGpsCollection_ModAPI.cs" />
     <Compile Include="ModAPI\MyGps_ModAPI.cs" />


### PR DESCRIPTION
Added MyAPIGateway.Utilities.CreateNotification() which returns an MyHudNotification object  (under the IMyHudNotification interface) that can be used to dynamically show, hide, change text, change font and change the alive time of the notification without needing to create another object.

A snippet from my test mod:
```
        bool init = false;
        private static Random rand = new Random();
        int fontSwap = 0;
        const int fontSwapMax = 15;
        IMyHudNotification notification;
        
        public void Init()
        {
            init = true;
            
            notification = MyAPIGateway.Utilities.CreateNotification("Test :}", 20, MyFontEnum.Red);
            notification.Show();
        }
        
        public override void UpdateAfterSimulation()
        {
            if(MyAPIGateway.Session == null)
                return;
            
            if(!init)
            {
                Init();
            }
            
            if(++fontSwap >= fontSwapMax)
            {
                fontSwap = 0;
                notification.Font = (notification.Font == MyFontEnum.Red ? MyFontEnum.Blue : MyFontEnum.Red);
            }
            
            notification.Text = "random=" + rand.NextDouble();
            notification.ResetAliveTime();
       }
```