### PR TITLE
Improved assembler pull for faster assemblers.

### DIFF
--- a/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_ProductionBlock.cs
+++ b/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_ProductionBlock.cs
@@ -56,8 +56,8 @@ namespace Sandbox.Common.ObjectBuilders
         public override void SetupForProjector()
         {
             base.SetupForProjector();
-            if (Inventory != null)
-                Inventory.Clear();
+            if (InputInventory != null)
+                InputInventory.Clear();
             if (OutputInventory != null)
                 OutputInventory.Clear();
         }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
@@ -582,7 +582,7 @@ namespace Sandbox.Game.Entities.Cube
                                     {
                                         availableAmount = 0;
                                     }
-                                    var neededAmount = ((VRage.MyFixedPoint)((float)component.Amount * 1 / MySession.Static.AssemblerEfficiencyMultiplier)) * itemAmount - availableAmount;
+                                    var neededAmount = ((VRage.MyFixedPoint)((float)component.Amount / MySession.Static.AssemblerEfficiencyMultiplier)) * itemAmount - availableAmount;
                                     if (neededAmount <= 0) continue;
 
                                     MyGridConveyorSystem.ItemPullRequest(this, InputInventory, OwnerId, component.Id, neededAmount);

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
@@ -563,15 +563,14 @@ namespace Sandbox.Game.Entities.Cube
                             var item = TryGetQueueItem(i);
                             if (item.HasValue)
                             {
-                                var factor = MySession.Static.AssemblerSpeedMultiplier / MySession.Static.AssemblerEfficiencyMultiplier;
+                                var factor = (MySession.Static.AssemblerSpeedMultiplier * ((MyAssemblerDefinition)BlockDefinition).AssemblySpeed + UpgradeValues["Productivity"]);
                                 var itemAmount = 1;
                                 var remainingTime = TIME_IN_ADVANCE - time;
-                                if (item.Value.Blueprint.BaseProductionTimeInSeconds < remainingTime)
+                                if ((item.Value.Blueprint.BaseProductionTimeInSeconds / factor) <= remainingTime)
                                 {
                                     itemAmount = Math.Min((int)item.Value.Amount, Convert.ToInt32(Math.Floor(remainingTime / (item.Value.Blueprint.BaseProductionTimeInSeconds / factor))));
-                                    time += itemAmount * item.Value.Blueprint.BaseProductionTimeInSeconds / MySession.Static.AssemblerSpeedMultiplier;
+                                    time += itemAmount * item.Value.Blueprint.BaseProductionTimeInSeconds / factor;
                                     if (time < TIME_IN_ADVANCE)
-
                                     {
                                         next = true;
                                     }
@@ -583,7 +582,7 @@ namespace Sandbox.Game.Entities.Cube
                                     {
                                         availableAmount = 0;
                                     }
-                                    var neededAmount = component.Amount * itemAmount - availableAmount;
+                                    var neededAmount = ((VRage.MyFixedPoint)((float)component.Amount * 1 / MySession.Static.AssemblerEfficiencyMultiplier)) * itemAmount - availableAmount;
                                     if (neededAmount <= 0) continue;
 
                                     MyGridConveyorSystem.ItemPullRequest(this, InputInventory, OwnerId, component.Id, neededAmount);


### PR DESCRIPTION
Modified calculations of the assembler updates to properly calculate the correct amount of ingots for the assemblers to use.  This should also work with 10x assemblers in 10x environments.

(This does not address the max 1 item per 10 frames.  That is coming in my next commit.)