### PR TITLE
Fix against vibrating and shaking small 1x1 suspension block

### DIFF
--- a/Sources/SpaceEngineers/Content/Data/CubeBlocks.sbc
+++ b/Sources/SpaceEngineers/Content/Data/CubeBlocks.sbc
@@ -18299,6 +18299,7 @@
       <MaxForceMagnitude>3.36E+07</MaxForceMagnitude>
       <RotorPart>RealWheel1x1</RotorPart>
       <PropulsionForce>50</PropulsionForce>
+      <SuspensionLimit>0.25</SuspensionLimit>
       <MinHeight>-0.32</MinHeight>
       <MaxHeight>0.26</MaxHeight>
       <DamageEffectId>212</DamageEffectId>


### PR DESCRIPTION
 Fixes the vibrating of the small 1x1 suspension if value has been changed too quickly from min to max.
See comments on Pull Request https://github.com/KeenSoftwareHouse/SpaceEngineers/pull/120