### PR TITLE
Fix characters dying suddenly when exiting cockpit.

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyCockpit.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyCockpit.cs
@@ -627,6 +627,12 @@ namespace Sandbox.Game.Entities
             if (usePilotOriginalWorld || allowedPosition.HasValue)
             {
                 Hierarchy.RemoveChild(m_pilot);
+
+                MyObjectBuilder_Character characterOb = (MyObjectBuilder_Character)m_pilot.GetObjectBuilder();
+                m_pilot.Physics.Close();
+                m_pilot.Physics = null;
+                m_pilot.Init(characterOb);
+                
                 MyEntities.Add(m_pilot);
                 m_pilot.Physics.Enabled = true;
                 m_rechargeSocket.Unplug();


### PR DESCRIPTION
This seems to fix the issue with characters dying instantly upon exiting a cockpit, especially while travelling at high speed, or in creative mode suddenly flying off uncontrollably. It is motivated by the observation that removing and putting back on your helmet will restore control. To be quite honest, I am not entirely sure why this works, but it seems to fix the problem.