### PR TITLE
Fix: Turning off blinking doesn't let the light shine

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyLightingBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyLightingBlock.cs
@@ -248,6 +248,12 @@ namespace Sandbox.Game.Entities.Blocks
                 if (m_blinkIntervalSeconds != value)
                 {
                     m_blinkIntervalSeconds = (float)Math.Round(value, NUM_DECIMALS);
+                    if (m_blinkIntervalSeconds == 0.0f && Enabled)
+                    {
+                        m_light.ReflectorOn = true;
+                        m_light.GlareOn = true;
+                        m_light.LightOn = true;
+                    }
                     RaisePropertiesChanged();
                 }
             }


### PR DESCRIPTION
This code fixes the following problem:
A light blinks perfectly when setting up an interval. But as soon as the interval is set to 0, there are two different outcomes:
1. The light was shining, then it continues to shine
2. The light was not shining, then it continues to not shine even though it's still turned on. The light has to be switched off and on again to make it emitting light.

With this fix, the light shines again when the interval is set to 0 and is turned on.