### PR TITLE
Suspension extensions (+fix)

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyMotorSuspension.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyMotorSuspension.cs
@@ -8,11 +8,49 @@ namespace Sandbox.ModAPI.Ingame
     public interface IMyMotorSuspension : IMyMotorBase
     {
         bool Steering { get; }
+
         bool Propulsion { get; }
-        float Damping { get;}
-        float Strength { get;}
-        float Friction { get;}
+
+        bool InvertSteer { get; }
+
+        float Damping { get; }
+
+        float Strength { get; }
+
+        float Friction { get; }
+
         float Power { get; }
+
         float Height { get; }
+
+        /// <summary>
+        /// Wheel's current steering angle
+        /// </summary>
+        float SteerAngle { get; }
+
+        /// <summary>
+        /// Max steering angle in radians.
+        /// </summary>
+        float MaxSteerAngle { get; }
+
+        /// <summary>
+        /// Speed at which wheel steers.
+        /// </summary>
+        float SteerSpeed { get; }
+
+        /// <summary>
+        /// Speed at which wheel returns from steering.
+        /// </summary>
+        float SteerReturnSpeed { get; }
+
+        /// <summary>
+        /// Suspension travel, value from 0 to 1.
+        /// </summary>
+        float SuspensionTravel { get; }
+
+        /// <summary>
+        /// Set/get brake applied to the wheel.
+        /// </summary>
+        bool Brake { get; set; }
     }
 }

--- a/Sources/Sandbox.Game/Definitions/MyMotorSuspensionDefinition.cs
+++ b/Sources/Sandbox.Game/Definitions/MyMotorSuspensionDefinition.cs
@@ -13,7 +13,6 @@ namespace Sandbox.Definitions
         public float MaxSteer;
         public float SteeringSpeed;
         public float PropulsionForce;
-        public float SuspensionLimit;
         public float MinHeight;
         public float MaxHeight;
 
@@ -25,7 +24,6 @@ namespace Sandbox.Definitions
             MaxSteer = ob.MaxSteer;
             SteeringSpeed = ob.SteeringSpeed;
             PropulsionForce = ob.PropulsionForce;
-            SuspensionLimit = ob.SuspensionLimit;
             MinHeight = ob.MinHeight;
             MaxHeight = ob.MaxHeight;
         }

--- a/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
+++ b/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
@@ -6170,6 +6170,56 @@ namespace Sandbox.Game.Localization
         public static readonly MyStringId BlockPropertyTitle_Motor_Height = MyStringId.GetOrCompute("BlockPropertyTitle_Motor_Height");
 
         ///<summary>
+        ///The maximum angle that the wheel will turn when steering
+        ///</summary>
+        public static readonly MyStringId BlockPropertyDescription_Motor_MaxSteerAngle = MyStringId.GetOrCompute("BlockPropertyDescription_Motor_MaxSteerAngle");
+
+        ///<summary>
+        ///Steering Angle
+        ///</summary>
+        public static readonly MyStringId BlockPropertyTitle_Motor_MaxSteerAngle = MyStringId.GetOrCompute("BlockPropertyTitle_Motor_MaxSteerAngle");
+
+        ///<summary>
+        ///The wheel turn speed.
+        ///</summary>
+        public static readonly MyStringId BlockPropertyDescription_Motor_SteerSpeed = MyStringId.GetOrCompute("BlockPropertyDescription_Motor_SteerSpeed");
+
+        ///<summary>
+        ///Steering Speed
+        ///</summary>
+        public static readonly MyStringId BlockPropertyTitle_Motor_SteerSpeed = MyStringId.GetOrCompute("BlockPropertyTitle_Motor_SteerSpeed");
+
+        ///<summary>
+        ///The wheel's return speed from turning.
+        ///</summary>
+        public static readonly MyStringId BlockPropertyDescription_Motor_SteerReturnSpeed = MyStringId.GetOrCompute("BlockPropertyDescription_Motor_SteerReturnSpeed");
+
+        ///<summary>
+        ///Steer Return Speed
+        ///</summary>
+        public static readonly MyStringId BlockPropertyTitle_Motor_SteerReturnSpeed = MyStringId.GetOrCompute("BlockPropertyTitle_Motor_SteerReturnSpeed");
+
+        ///<summary>
+        ///Invert the steering direction.
+        ///</summary>
+        public static readonly MyStringId BlockPropertyDescription_Motor_InvertSteer = MyStringId.GetOrCompute("BlockPropertyDescription_Motor_InvertSteer");
+
+        ///<summary>
+        ///Invert Steering
+        ///</summary>
+        public static readonly MyStringId BlockPropertyTitle_Motor_InvertSteer = MyStringId.GetOrCompute("BlockPropertyTitle_Motor_InvertSteer");
+
+        ///<summary>
+        ///Limits the suspension's travel height. Setting to 0% will effectively lock the suspension.
+        ///</summary>
+        public static readonly MyStringId BlockPropertyDescription_Motor_SuspensionTravel = MyStringId.GetOrCompute("BlockPropertyDescription_Motor_SuspensionTravel");
+
+        ///<summary>
+        ///Suspension Travel
+        ///</summary>
+        public static readonly MyStringId BlockPropertyTitle_Motor_SuspensionTravel = MyStringId.GetOrCompute("BlockPropertyTitle_Motor_SuspensionTravel");
+
+        ///<summary>
         ///Centered Window
         ///</summary>
         public static readonly MyStringId DisplayName_Block_VerticalCen = MyStringId.GetOrCompute("DisplayName_Block_VerticalCen");

--- a/Sources/Sandbox.Game/Game/Multiplayer/MySyncMotorSuspension.cs
+++ b/Sources/Sandbox.Game/Game/Multiplayer/MySyncMotorSuspension.cs
@@ -104,7 +104,7 @@ namespace Sandbox.Game.Multiplayer
         }
 
         [MessageId(239, P2PMessageEnum.Reliable)]
-        struct HeightMsg : IEntityMessage
+        struct UpdateSliderMsg : IEntityMessage
         {
             public long EntityId;
 
@@ -113,7 +113,18 @@ namespace Sandbox.Game.Multiplayer
                 return EntityId;
             }
 
-            public float Height;
+            public SliderEnum Slider;
+            public float Value;
+        }
+
+        public enum SliderEnum
+        {
+            Height,
+            MaxSteerAngle,
+            SteerSpeed,
+            SteerReturnSpeed,
+            InvertSteer,
+            SuspensionTravel
         }
 
         static MySyncMotorSuspension()
@@ -125,7 +136,7 @@ namespace Sandbox.Game.Multiplayer
             MySyncLayer.RegisterEntityMessage<MySyncMotorSuspension, FrictionMsg>(OnChangeFriction, MyMessagePermissions.Any);
             MySyncLayer.RegisterEntityMessage<MySyncMotorSuspension, PowerMsg>(OnChangePower, MyMessagePermissions.Any);
             MySyncLayer.RegisterEntityMessage<MySyncMotorSuspension, SteerMsg>(OnUpdateSteer, MyMessagePermissions.Any);
-            MySyncLayer.RegisterEntityMessage<MySyncMotorSuspension, HeightMsg>(OnChangeHeight, MyMessagePermissions.Any);
+            MySyncLayer.RegisterEntityMessage<MySyncMotorSuspension, UpdateSliderMsg>(OnUpdateSlider, MyMessagePermissions.Any);
         }
 
         public new MyMotorSuspension Entity
@@ -238,18 +249,39 @@ namespace Sandbox.Game.Multiplayer
             sync.Entity.SteerAngle = msg.Steer;
         }
 
-        internal void ChangeHeight(float v)
+        internal void ChangeSlider(MySyncMotorSuspension.SliderEnum slider, float v)
         {
-            var msg = new HeightMsg();
+            var msg = new UpdateSliderMsg();
             msg.EntityId = Entity.EntityId;
-            msg.Height = v;
+            msg.Slider = slider;
+            msg.Value = v;
 
             Sync.Layer.SendMessageToAllAndSelf(ref msg);
         }
 
-        static void OnChangeHeight(MySyncMotorSuspension sync, ref HeightMsg msg, MyNetworkClient sender)
+        static void OnUpdateSlider(MySyncMotorSuspension sync, ref UpdateSliderMsg msg, MyNetworkClient sender)
         {
-            sync.Entity.Height = msg.Height;
+            switch (msg.Slider)
+            {
+                case SliderEnum.Height:
+                    sync.Entity.Height = msg.Value;
+                    break;
+                case SliderEnum.MaxSteerAngle:
+                    sync.Entity.MaxSteerAngle = msg.Value;
+                    break;
+                case SliderEnum.SteerSpeed:
+                    sync.Entity.SteerSpeed = msg.Value;
+                    break;
+                case SliderEnum.SteerReturnSpeed:
+                    sync.Entity.SteerReturnSpeed = msg.Value;
+                    break;
+                case SliderEnum.InvertSteer:
+                    sync.Entity.InvertSteer = msg.Value > 0;
+                    break;
+                case SliderEnum.SuspensionTravel:
+                    sync.Entity.SuspensionTravel = msg.Value;
+                    break;
+            }
         }
     }
 }

--- a/Sources/Sandbox.Game/ModAPI/MyMotorSuspension_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/MyMotorSuspension_ModAPI.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Sandbox.ModAPI.Ingame;
+using Havok;
+
+namespace Sandbox.Game.Entities.Cube
+{
+    partial class MyMotorSuspension : IMyMotorSuspension
+    {
+        bool IMyMotorSuspension.Steering { get { return Steering; } }
+        bool IMyMotorSuspension.Propulsion { get { return Propulsion; } }
+        bool IMyMotorSuspension.InvertSteer { get { return InvertSteer; } }
+        float IMyMotorSuspension.Damping { get { return GetDampingForTerminal(); } }
+        float IMyMotorSuspension.Strength { get { return GetStrengthForTerminal(); } }
+        float IMyMotorSuspension.Friction { get { return GetFrictionForTerminal(); } }
+        float IMyMotorSuspension.Power { get { return GetPowerForTerminal(); } }
+        float IMyMotorSuspension.Height { get { return GetHeightForTerminal(); } }
+        float IMyMotorSuspension.SteerAngle { get { return GetMaxSteerAngleForTerminal(); } }
+        float IMyMotorSuspension.MaxSteerAngle { get { return GetMaxSteerAngleForTerminal(); } }
+        float IMyMotorSuspension.SteerSpeed { get { return GetSteerSpeedForTerminal(); } }
+        float IMyMotorSuspension.SteerReturnSpeed { get { return GetSteerReturnSpeedForTerminal(); } }
+        float IMyMotorSuspension.SuspensionTravel { get { return GetSuspensionTravelForTerminal(); } }
+    }
+}

--- a/Sources/Sandbox.Game/Sandbox.Game.csproj
+++ b/Sources/Sandbox.Game/Sandbox.Game.csproj
@@ -712,6 +712,7 @@
     <Compile Include="Game\World\Triggers\MyTriggerPositionLeft.cs" />
     <Compile Include="Game\World\Triggers\MyTriggerSomeoneWon.cs" />
     <Compile Include="ModAPI\Blocks\MyTextPanel_ModAPI.cs" />
+    <Compile Include="ModAPI\MyMotorSuspension_ModAPI.cs" />
     <Compile Include="ModAPI\MyBlockGroup_ModAPI.cs" />
     <Compile Include="ModAPI\MyGpsCollection_ModAPI.cs" />
     <Compile Include="ModAPI\MyGps_ModAPI.cs" />

--- a/Sources/SpaceEngineers/Content/Data/CubeBlocks.sbc
+++ b/Sources/SpaceEngineers/Content/Data/CubeBlocks.sbc
@@ -18065,7 +18065,11 @@
       <RequiredPowerInput>0.002</RequiredPowerInput>
       <MaxForceMagnitude>3.36E+07</MaxForceMagnitude>
       <RotorPart>RealWheel</RotorPart>
-      <SuspensionLimit>0.7</SuspensionLimit>
+      <!-- The max angle (radians) that steer angle slider can go to. -->
+      <MaxSteer>0.8</MaxSteer>
+      <!-- The max value that steering speed and steer return speed sliders can go. -->
+      <SteeringSpeed>0.1</SteeringSpeed>
+      <!-- Min/Max height sets the physical boundaries of the suspension as well as the height slider limits. -->
       <MinHeight>-1.5</MinHeight>
       <MaxHeight>1.3</MaxHeight>
       <DamageEffectId>212</DamageEffectId>
@@ -18111,7 +18115,6 @@
       <RequiredPowerInput>0.002</RequiredPowerInput>
       <MaxForceMagnitude>3.36E+07</MaxForceMagnitude>
       <RotorPart>RealWheel5x5</RotorPart>
-      <SuspensionLimit>2.5</SuspensionLimit>
       <MinHeight>-1.5</MinHeight>
       <MaxHeight>1.3</MaxHeight>
       <DamageEffectId>212</DamageEffectId>
@@ -18159,7 +18162,6 @@
       <RequiredPowerInput>0.002</RequiredPowerInput>
       <MaxForceMagnitude>3.36E+07</MaxForceMagnitude>
       <RotorPart>RealWheel1x1</RotorPart>
-      <SuspensionLimit>0.6</SuspensionLimit>
       <MinHeight>-1.5</MinHeight>
       <MaxHeight>1.3</MaxHeight>
       <PropulsionForce>700</PropulsionForce>
@@ -18207,7 +18209,6 @@
       <MaxForceMagnitude>3.36E+07</MaxForceMagnitude>
       <RotorPart>RealWheel</RotorPart>
       <PropulsionForce>200</PropulsionForce>
-      <SuspensionLimit>0.25</SuspensionLimit>
       <MinHeight>-0.32</MinHeight>
       <MaxHeight>0.26</MaxHeight>
       <DamageEffectId>212</DamageEffectId>
@@ -18252,7 +18253,6 @@
       <MaxForceMagnitude>3.36E+07</MaxForceMagnitude>
       <RotorPart>RealWheel5x5</RotorPart>
       <PropulsionForce>200</PropulsionForce>
-      <SuspensionLimit>0.5</SuspensionLimit>
       <MinHeight>-0.50</MinHeight>
       <MaxHeight>0.35</MaxHeight>
       <DamageEffectId>212</DamageEffectId>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
@@ -3881,6 +3881,37 @@ Respawn?</value>
   <data name="BlockPropertyTitle_Motor_Height" xml:space="preserve">
     <value>Height Offset</value>
   </data>
+  <data name="BlockPropertyDescription_Motor_MaxSteerAngle" xml:space="preserve">
+    <value>The maximum angle that the wheel will turn when steering</value>
+  </data>
+  <data name="BlockPropertyTitle_Motor_MaxSteerAngle" xml:space="preserve">
+    <value>Steering Angle</value>
+  </data>
+  <data name="BlockPropertyDescription_Motor_SteerSpeed" xml:space="preserve">
+    <value>The wheel turn speed.</value>
+  </data>
+  <data name="BlockPropertyTitle_Motor_SteerSpeed" xml:space="preserve">
+    <value>Steering Speed</value>
+  </data>
+  <data name="BlockPropertyDescription_Motor_SteerReturnSpeed" xml:space="preserve">
+    <value>The wheel's return speed from turning.</value>
+  </data>
+  <data name="BlockPropertyTitle_Motor_SteerReturnSpeed" xml:space="preserve">
+    <value>Steer Return Speed</value>
+  </data>
+  <data name="BlockPropertyDescription_Motor_InvertSteer" xml:space="preserve">
+    <value>Invert the steering direction.</value>
+  </data>
+  <data name="BlockPropertyTitle_Motor_InvertSteer" xml:space="preserve">
+    <value>Invert Steering</value>
+  </data>
+  <data name="BlockPropertyDescription_Motor_SuspensionTravel" xml:space="preserve">
+    <value>Limits the suspension's travel height.
+Setting to 0% will effectively lock the suspension.</value>
+  </data>
+  <data name="BlockPropertyTitle_Motor_SuspensionTravel" xml:space="preserve">
+    <value>Suspension Travel</value>
+  </data>
   <data name="DisplayName_Block_VerticalCen" xml:space="preserve">
     <value>Centered Window</value>
   </data>

--- a/Sources/VRage.Game/ObjectBuilders/Definitions/MyObjectBuilder_MotorSuspensionDefinition.cs
+++ b/Sources/VRage.Game/ObjectBuilders/Definitions/MyObjectBuilder_MotorSuspensionDefinition.cs
@@ -12,16 +12,13 @@ namespace Sandbox.Common.ObjectBuilders.Definitions
     public class MyObjectBuilder_MotorSuspensionDefinition : MyObjectBuilder_MotorStatorDefinition
     {
         [ProtoMember]
-        public float MaxSteer = 0.45f;
+        public float MaxSteer = 0.8f;
 
         [ProtoMember]
-        public float SteeringSpeed = 0.02f;
+        public float SteeringSpeed = 0.1f;
 
         [ProtoMember]
         public float PropulsionForce = 10000;
-
-        [ProtoMember]
-        public float SuspensionLimit = 0.1f;
 
         [ProtoMember]
         public float MinHeight = -0.32f;

--- a/Sources/VRage.Game/ObjectBuilders/MyObjectBuilder_MotorSuspension.cs
+++ b/Sources/VRage.Game/ObjectBuilders/MyObjectBuilder_MotorSuspension.cs
@@ -31,5 +31,20 @@ namespace Sandbox.Common.ObjectBuilders
 
         [ProtoMember]
         public float Height = 0;
+
+        [ProtoMember]
+        public float MaxSteerAngle = 0.45f;
+
+        [ProtoMember]
+        public float SteerSpeed = 0.02f;
+
+        [ProtoMember]
+        public float SteerReturnSpeed = 0.01f;
+
+        [ProtoMember]
+        public bool InvertSteer = false;
+
+        [ProtoMember]
+        public float SuspensionTravel = 100;
     }
 }


### PR DESCRIPTION
- Added sliders for steering angle, steering speed, steer return speed, suspension travel (which can also be used to lock the suspension) and a checkbox to invert steer direction;
- Reoriganized the control panel: [panel part 1](http://i.imgur.com/b9F6s7n.jpg), [panel part 2](http://i.imgur.com/d9GeHPw.jpg);
- Removed "SuspensionLimit" cubeblock parameter and made "MinHeight" and "MaxHeight" to act as suspension limits instead;
- The added sliders are set by default to the values they were set prior to having sliders but their respective value limits have been increased a bit to allow more customization;
- Added the MyMotorSuspension_ModAPI class and moved the mod API related code there and updated IMyMotorSuspension;
- If the suspension body doesn't have a wheel attached, all suspension controls are disabled;
- Fixed the shaking described in https://github.com/KeenSoftwareHouse/SpaceEngineers/pull/120