### PR TITLE
Fixed Check for DX11 support

### DIFF
--- a/Sources/VRage.Render11/Render/MyRender-Adapters.cs
+++ b/Sources/VRage.Render11/Render/MyRender-Adapters.cs
@@ -205,7 +205,7 @@ namespace VRageRender
 
                 LogAdapterInfoBegin(ref info);
 
-                if(supportedDevice)
+                if(supportedDevice && vram > 0)
                 {
                     for(int j=0; j<factory.Adapters[i].Outputs.Length; j++)
                     {
@@ -242,13 +242,14 @@ namespace VRageRender
                         LogOutputDisplayModes(ref info);
                     }
                 }
+                /* nope, not supported
                 else
                 {
                     info.SupportedDisplayModes = new MyDisplayMode[0];
                     adaptersList.Add(info);
                     adapterIndex++;
                 }
-
+                */
                 LogAdapterInfoEnd();
 
                 if(adapterTestDevice != null)


### PR DESCRIPTION
current check added microsoft software render into list (this is installed by IE7 and newer), therefore game detected DX11 support without DX11 hardware

tested with help of @THDigi 