### PR TITLE
Add custom DetailedInfo text that can be changed in-game

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyTerminalBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyTerminalBlock.cs
@@ -11,11 +11,14 @@ namespace Sandbox.ModAPI.Ingame
         string CustomName { get; }
         string CustomNameWithFaction { get; }
         string DetailedInfo { get; }
+        string CustomDetailedInfo { get; }
         bool HasLocalPlayerAccess();
         bool HasPlayerAccess(long playerId);
         void RequestShowOnHUD(bool enable);
         void SetCustomName(string text);
         void SetCustomName(StringBuilder text);
+        void SetCustomDetailedInfo(string text);
+        void SetCustomDetailedInfo(StringBuilder text);
         bool ShowOnHUD { get; }
         void GetActions(List<Sandbox.ModAPI.Interfaces.ITerminalAction> resultList, Func<Sandbox.ModAPI.Interfaces.ITerminalAction, bool> collect = null);
         void SearchActionsOfName(string name,List<Sandbox.ModAPI.Interfaces.ITerminalAction> resultList, Func<Sandbox.ModAPI.Interfaces.ITerminalAction, bool> collect = null);

--- a/Sources/Sandbox.Game/Engine/GUI/FunctionalBlocks/MyGuiControlGenericFunctionalBlock.cs
+++ b/Sources/Sandbox.Game/Engine/GUI/FunctionalBlocks/MyGuiControlGenericFunctionalBlock.cs
@@ -205,6 +205,8 @@ namespace Sandbox.Graphics.GUI
             if (m_currentBlocks.Count() == 1)
             {
                 m_blockPropertiesLabel.Text.AppendStringBuilder(m_currentBlocks[0].DetailedInfo);
+                m_blockPropertiesLabel.Text.Append("\n");
+                m_blockPropertiesLabel.Text.AppendStringBuilder(m_currentBlocks[0].CustomDetailedInfo);
             }
             m_blockPropertiesLabel.RefreshText(false);
             ProfilerShort.End();

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyTerminalBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyTerminalBlock.cs
@@ -92,6 +92,7 @@ namespace Sandbox.Game.Entities.Cube
         /// Detailed text in terminal (on right side)
         /// </summary>
         public StringBuilder DetailedInfo { get; private set; }
+        public StringBuilder CustomDetailedInfo { get; private set; }
 
         public event Action<MyTerminalBlock> CustomNameChanged;
         public event Action<MyTerminalBlock> PropertiesChanged;
@@ -105,6 +106,7 @@ namespace Sandbox.Game.Entities.Cube
             CustomName = new StringBuilder();
             DetailedInfo = new StringBuilder();
             CustomNameWithFaction = new StringBuilder();
+            CustomDetailedInfo = new StringBuilder();
         }
         public override void Init(MyObjectBuilder_CubeBlock objectBuilder, MyCubeGrid cubeGrid)
         {
@@ -175,7 +177,23 @@ namespace Sandbox.Game.Entities.Cube
             if (handler != null) handler(this);
         }
 
-       
+        public void SetCustomDetailedInfo(string text)
+        {
+            MySyncBlockHelpers.SendChangeCustomDetailedInfoRequest(this, text);
+        }
+
+        public void SetCustomDetailedInfo(StringBuilder text)
+        {
+            MySyncBlockHelpers.SendChangeCustomDetailedInfoRequest(this, text.ToString());
+        }
+
+        public void UpdateCustomDetailedInfo(string text)
+        {
+            if (CustomDetailedInfo.CompareUpdate(text))
+            {
+                RaisePropertiesChanged();
+            }
+        }
 
         /// <summary>
         /// Call this when you change detailed info or other terminal properties

--- a/Sources/Sandbox.Game/ModAPI/Blocks/MyTerminalBlock_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/Blocks/MyTerminalBlock_ModAPI.cs
@@ -23,6 +23,11 @@ namespace Sandbox.Game.Entities.Cube
             get { return DetailedInfo.ToString(); }
         }
 
+        string ModAPI.Ingame.IMyTerminalBlock.CustomDetailedInfo
+        {
+            get { return CustomDetailedInfo.ToString(); }
+        }
+
         Action<MyTerminalBlock> GetDelegate(Action<ModAPI.IMyTerminalBlock> value)
         {
             return (Action<MyTerminalBlock>)Delegate.CreateDelegate(typeof(Action<MyTerminalBlock>), value.Target, value.Method);


### PR DESCRIPTION
A new CustomDetailedInfo property has been added to allow modders or in-game script writers to append custom text to the DetailedInfo shown in the terminal.

**This will not affect the existing DetailedInfo property, which is still read-only.**

This is useful for custom upgrades, see screenshot.

![2015-05-30-02-31-49-901_finalscreen](https://cloud.githubusercontent.com/assets/1127170/7896656/0139ad1a-0675-11e5-96dd-b72ace92c2a0.png)
