### PR TITLE
Make sure Laser Antenna LoS requirement is checked at all LoS checks.

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
@@ -650,7 +650,7 @@ namespace Sandbox.Game.Entities.Cube
                         || !IsInRange(target)
                         || !m_receiver.CanIUseIt(target.m_broadcaster, this.OwnerId)
                         || !target.m_receiver.CanIUseIt(m_broadcaster, target.OwnerId)
-                        || (m_needLineOfSight && !LosTest(target.HeadPos))//target will make other half of line in its update
+                        || !LosTest(target.HeadPos)//target will make other half of line in its update
                         )
                         sync.ShiftMode(StateEnum.contact_Rec);//other side MIA
                     else
@@ -1130,6 +1130,9 @@ namespace Sandbox.Game.Entities.Cube
         }
         protected bool LosTest(Vector3D target)
         {//LOS test from me to half of distance to target, with maximum
+            if (!m_needLineOfSight)
+                return true;
+
             if (Vector3D.DistanceSquared(HeadPos, target) > m_Max_LosDist * m_Max_LosDist * 4)
                 target = HeadPos + Vector3D.Normalize(target - HeadPos) * m_Max_LosDist;
             else


### PR DESCRIPTION
My Laser Antenna Line-of-Sight change (pull request #45) didn't take into account all cases.
All it did was let you leave LoS while connected, it didn't allow you to connect while out of LoS.

This is a fix to handle all cases.