### PR TITLE
Terminalproperty bool value

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Interfaces/ITerminalProperty.cs
+++ b/Sources/Sandbox.Common/ModAPI/Interfaces/ITerminalProperty.cs
@@ -53,6 +53,11 @@ namespace Sandbox.ModAPI.Interfaces
             return property.As<Color>();
         }
 
+        public static ITerminalProperty<bool> AsBool(this ITerminalProperty property)
+        {
+            return property.As<bool>();
+        }
+
         public static float GetValueFloat(this Ingame.IMyTerminalBlock block, string propertyId)
         {
             return block.GetValue<float>(propertyId);
@@ -61,6 +66,16 @@ namespace Sandbox.ModAPI.Interfaces
         public static void SetValueFloat(this Ingame.IMyTerminalBlock block, string propertyId, float value)
         {
             block.SetValue<float>(propertyId, value);
+        }
+
+        public static bool GetValueBool(this Ingame.IMyTerminalBlock block, string propertyId)
+        {
+            return block.GetValue<bool>(propertyId);
+        }
+
+        public static void SetValueBool(this Ingame.IMyTerminalBlock block, string propertyId, bool value)
+        {
+            block.SetValue<bool>(propertyId, value);
         }
 
         public static void SetValue<T>(this Ingame.IMyTerminalBlock block, string propertyId, T value)

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlCheckbox.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlCheckbox.cs
@@ -15,7 +15,7 @@ using VRage.Library.Utils;
 
 namespace Sandbox.Game.Gui
 {
-    class MyTerminalControlCheckbox<TBlock> : MyTerminalControl<TBlock>
+    class MyTerminalControlCheckbox<TBlock> : MyTerminalValueControl<TBlock, bool>
         where TBlock : MyTerminalBlock
     {
         Action<TBlock> m_action;
@@ -72,6 +72,16 @@ namespace Sandbox.Game.Gui
             Setter(block, !Getter(block));
         }
 
+        void CheckAction(TBlock block)
+        {
+            Setter(block, true);
+        }
+
+        void UncheckAction(TBlock block)
+        {
+            Setter(block, false);
+        }
+
         void Writer(TBlock block, StringBuilder result, StringBuilder onText, StringBuilder offText)
         {
             result.Append(Getter(block) ? onText : offText);
@@ -83,6 +93,31 @@ namespace Sandbox.Game.Gui
             Actions = new MyTerminalAction<TBlock>[] { action };
 
             return action;
+        }
+
+        public override bool GetValue(TBlock block)
+        {
+            return Getter(block);
+        }
+
+        public override void SetValue(TBlock block, bool value)
+        {
+            Setter(block, value);
+        }
+
+        public override bool GetDefaultValue(TBlock block)
+        {
+            return false;
+        }
+
+        public override bool GetMininum(TBlock block)
+        {
+            return false;
+        }
+
+        public override bool GetMaximum(TBlock block)
+        {
+            return true;
         }
     }
 }

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlOnOffSwitch.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlOnOffSwitch.cs
@@ -19,7 +19,7 @@ using VRage.Library.Utils;
 
 namespace Sandbox.Game.Gui
 {
-    class MyTerminalControlOnOffSwitch<TBlock> : MyTerminalControl<TBlock>
+    class MyTerminalControlOnOffSwitch<TBlock> : MyTerminalValueControl<TBlock, bool>
         where TBlock : MyTerminalBlock
     {
         public delegate bool GetterDelegate(TBlock block);
@@ -141,6 +141,31 @@ namespace Sandbox.Game.Gui
             AppendAction(action);
 
             return action;
+        }
+
+        public override bool GetValue(TBlock block)
+        {
+            return Getter(block);
+        }
+
+        public override void SetValue(TBlock block, bool value)
+        {
+            Setter(block, value);
+        }
+
+        public override bool GetDefaultValue(TBlock block)
+        {
+            return false;
+        }
+
+        public override bool GetMininum(TBlock block)
+        {
+            return false;
+        }
+
+        public override bool GetMaximum(TBlock block)
+        {
+            return true;
         }
     }
 }


### PR DESCRIPTION
bool is used for populating state of on/off button/checkbox for PB, so you don't need to compare WriteValue with "On/Off" value, which can be language specific.

On/Off button and checkbox will appear in list retrieved by IMyTerminalBlock.GetProperties, and you can evaluate it using GetValue<bool>("name") or modify using SetValue<bool>("name", true | false)