### PR TITLE
Added 2 decimal places to Oxygen Tank capacity 

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenTank.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenTank.cs
@@ -369,7 +369,7 @@ namespace Sandbox.Game.Entities.Blocks
             }
             else
             {
-                DetailedInfo.Append("Filled: " + (FilledRatio * 100f).ToString("F") + "%");
+                DetailedInfo.Append("Filled: " + (FilledRatio * 100f).ToString("F4") + "%");
             }
 
             RaisePropertiesChanged();

--- a/SpaceEngineers.sln
+++ b/SpaceEngineers.sln
@@ -72,6 +72,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Configuration", "Configuration", "{BB2E2FD7-114E-441E-A282-643353F31A64}"
 	ProjectSection(SolutionItems) = preProject
 		global.props = global.props
+		user.props = user.props
 	EndProjectSection
 EndProject
 Global

--- a/SpaceEngineers.sln
+++ b/SpaceEngineers.sln
@@ -72,7 +72,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Configuration", "Configuration", "{BB2E2FD7-114E-441E-A282-643353F31A64}"
 	ProjectSection(SolutionItems) = preProject
 		global.props = global.props
-		user.props = user.props
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
Due to Oxygen Farm production being as slow as it is. The time for 1 Farm to add 0.01% to a tank made it difficult to tell if things were working and connected correctly.