### PR TITLE
(Fix) Helmet toggle notifications not being overwritten

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Character/MyCharacter.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Character/MyCharacter.cs
@@ -808,7 +808,7 @@ namespace Sandbox.Game.Entities.Character
             m_broadcastingNotification = new MyHudNotification();
             m_inertiaDampenersNotification = new MyHudNotification();
             m_jetpackToggleNotification = new MyHudNotification();
-            m_helmetToggleNotification = new MyHudNotification();
+            m_helmetToggleNotification = m_helmetToggleNotification ?? new MyHudNotification(); // Init() is called when toggling helmet so this check is required
 
             m_needsOxygen = Definition.NeedsOxygen;
 


### PR DESCRIPTION
Related to my previous PR: https://github.com/KeenSoftwareHouse/SpaceEngineers/pull/136

This fixes the helmet on/off/unavailable notifications from not being overwritten.

Credit goes to @lord-devious for figuring it out :}