### PR TITLE
MyShipDrill: Expose Destroy/Fast No Collection Mode to GUI and ModAPI

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyShipDrill.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyShipDrill.cs
@@ -8,5 +8,6 @@ namespace Sandbox.ModAPI.Ingame
     public interface IMyShipDrill : IMyFunctionalBlock
     {
         bool UseConveyorSystem { get; }
+        bool InDestroyMode { get; }
     }
 }

--- a/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
+++ b/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
@@ -10458,5 +10458,15 @@ namespace Sandbox.Game.Localization
         ///Scenario
         ///</summary>
         public static readonly MyStringId WorldSettings_GameScenario = MyStringId.GetOrCompute("WorldSettings_GameScenario");
+
+        ///<summary>
+        ///Destroy mode
+        ///</summary>
+        public static readonly MyStringId Drill_Destroy = MyStringId.GetOrCompute("Drill_Destroy");
+
+        ///<summary>
+        ///Drill works faster but collects no ore
+        ///</summary>
+        public static readonly MyStringId Drill_Destroy_Tooltip = MyStringId.GetOrCompute("Drill_Destroy_Tooltip");
     }
 }

--- a/Sources/Sandbox.Game/Game/Weapons/Guns/MyShipDrill.cs
+++ b/Sources/Sandbox.Game/Game/Weapons/Guns/MyShipDrill.cs
@@ -80,6 +80,14 @@ namespace Sandbox.Game.Weapons
                 MetalLoop = new MySoundPair("ToolShipDrillMetal"),
                 RockLoop = new MySoundPair("ToolShipDrillRock"),
             };
+
+            var shouldDestroy = new MyTerminalControlOnOffSwitch<MyShipDrill>("ShouldDestroy", MySpaceTexts.Drill_Destroy, MySpaceTexts.Drill_Destroy_Tooltip);
+            shouldDestroy.Getter = (x) => !x.m_wantsToCollect;
+            shouldDestroy.Setter = (x, v) => x.m_wantsToCollect = !x.m_wantsToCollect;
+            shouldDestroy.EnableToggleAction();
+            MyTerminalControlFactory.AddControl(shouldDestroy);
+
+
         }
 
         public MyCharacter Owner { get { return m_owner; } }
@@ -278,7 +286,7 @@ namespace Sandbox.Game.Weapons
                 return;
             m_drillFrameCountdown += MyDrillConstants.DRILL_UPDATE_INTERVAL_IN_FRAMES;
             m_drillBase.IgnoredEntities.Add(Parent);
-            if (m_drillBase.Drill(collectOre: Enabled || m_wantsToCollect, performCutout: true))
+            if (m_drillBase.Drill(collectOre: m_wantsToCollect, performCutout: true))
             {
                 foreach (var c in CubeGrid.GetBlocks())
                 {
@@ -370,6 +378,7 @@ namespace Sandbox.Game.Weapons
         public void EndShoot(MyShootActionEnum action)
         {
             m_wantsToDrill = false;
+            m_wantsToCollect = false;
             PowerReceiver.Update();
         }
 
@@ -520,6 +529,14 @@ namespace Sandbox.Game.Weapons
             get
             {
                 return (this as IMyInventoryOwner).UseConveyorSystem;
+            }
+        }
+
+        bool Sandbox.ModAPI.Ingame.IMyShipDrill.InDestroyMode
+        {
+            get
+            {
+                return !m_wantsToCollect;
             }
         }
 

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
@@ -6474,4 +6474,10 @@ To connect to lasers not listed here you can connect to coordinates.</value>
   <data name="WorldSettings_GameScenario" xml:space="preserve">
     <value>Scenario</value>
   </data>
+  <data name="Drill_Destroy" xml:space="preserve">
+    <value>Destroy mode</value>
+  </data>
+  <data name="Drill_Destroy_Tooltip" xml:space="preserve">
+    <value>Drill works faster but collects no ore</value>
+  </data>
 </root>


### PR DESCRIPTION
Allows players to enable destroy mode (where the drills do not collect ore but work faster) through the GUI or through a toolbar item, instead of only allowing players to do this through holding down right click.

At the moment, "destroy" mode is useful for hollowing out large areas, but it requires the right mouse button to be held down on a Drill toolbar item taken from the "Weapons and Tools" area.  Quickly mining out areas with destroy mode currently requires an AutoHotKey script or other workarounds.  This PR would allow players to easily toggle this mode.

After a player finishes destorying with right-click m_wantsToCollect is set back to "false", so that drills activated in destroy mode through the mouse are not permanently set to destroy.

This is my first Space Engineers PR, so I'm not sure if I'm missing anything, such as network code.  Tested in SP, not in MP.