### PR TITLE
Advanced Door Bug fix

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectAdvancedDoorTerminal.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyUseObjectAdvancedDoorTerminal.cs
@@ -13,7 +13,7 @@ using VRage.ModAPI;
 
 namespace Sandbox.Game.Entities.Cube
 {
-    [MyUseObject("terminal")]
+    [MyUseObject("advdoor")]
     public class MyUseObjectAdvancedDoorTerminal: IMyUseObject
     {
         public readonly MyAdvancedDoor Door;


### PR DESCRIPTION
change [MyUseObject("terminal")] to [MyUseObject("advdoor")] with MyUseObjectAdvancedDoorTerminal ,
the "terminal" already use to MyUseObjectTerminal