### PR TITLE
Expose more types and properties as public

### DIFF
--- a/Sources/Sandbox.Game/Engine/Multiplayer/MyDedicatedServer.cs
+++ b/Sources/Sandbox.Game/Engine/Multiplayer/MyDedicatedServer.cs
@@ -143,7 +143,7 @@ namespace Sandbox.Engine.Multiplayer
 
     #endregion
 
-    class MyDedicatedServer : MyMultiplayerBase
+    public class MyDedicatedServer : MyMultiplayerBase
     {
         #region Fields
 

--- a/Sources/Sandbox.Game/Engine/Platform/Game.cs
+++ b/Sources/Sandbox.Game/Engine/Platform/Game.cs
@@ -102,7 +102,9 @@ namespace Sandbox.Engine.Platform
         /// </summary>
         public bool IsRunning { get; private set; }
 
-        #endregion
+	    public bool IsFirstUpdateDone { get { return isFirstUpdateDone; } }
+
+	    #endregion
 
         #region Public Methods and Operators
 


### PR DESCRIPTION
SEServerExtender uses this field quite a bit. Let's expose it as a public, read-only property, so I don't have to reflect against it any more.