### PR TITLE
Feature: Terminalproperty checkbox actions

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
@@ -329,7 +329,7 @@ namespace Sandbox.Game.Entities.Cube
                     x.SyncObject.RequestSlaveSwitch(v);
 
                 };
-                slaveCheck.EnableAction();
+                slaveCheck.EnableToggleAction();
                 MyTerminalControlFactory.AddControl(slaveCheck);
             }
         }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyBatteryBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyBatteryBlock.cs
@@ -67,13 +67,13 @@ namespace Sandbox.Game.Entities
             recharge.Setter = (x, v) => x.SyncObject.SendProducerEnableChange(!v);
             recharge.Enabled = (x) => !x.SemiautoEnabled;
             recharge.EnableToggleAction();
+            recharge.EnableOnOffActions();
+            MyTerminalControlFactory.AddControl(recharge);
 
             var semiAuto = new MyTerminalControlCheckbox<MyBatteryBlock>("SemiAuto", MySpaceTexts.BlockPropertyTitle_Semiauto, MySpaceTexts.ToolTipBatteryBlock_Semiauto);
             semiAuto.Getter = (x) => x.SemiautoEnabled;
             semiAuto.Setter = (x, v) => x.SyncObject.SendSemiautoEnableChange(v);
             semiAuto.EnableToggleAction();
-
-            MyTerminalControlFactory.AddControl(recharge);
             MyTerminalControlFactory.AddControl(semiAuto);
         }
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyBatteryBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyBatteryBlock.cs
@@ -66,12 +66,12 @@ namespace Sandbox.Game.Entities
             recharge.Getter = (x) => !x.ProductionEnabled;
             recharge.Setter = (x, v) => x.SyncObject.SendProducerEnableChange(!v);
             recharge.Enabled = (x) => !x.SemiautoEnabled;
-            recharge.EnableAction();
+            recharge.EnableToggleAction();
 
             var semiAuto = new MyTerminalControlCheckbox<MyBatteryBlock>("SemiAuto", MySpaceTexts.BlockPropertyTitle_Semiauto, MySpaceTexts.ToolTipBatteryBlock_Semiauto);
             semiAuto.Getter = (x) => x.SemiautoEnabled;
             semiAuto.Setter = (x, v) => x.SyncObject.SendSemiautoEnableChange(v);
-            semiAuto.EnableAction();
+            semiAuto.EnableToggleAction();
 
             MyTerminalControlFactory.AddControl(recharge);
             MyTerminalControlFactory.AddControl(semiAuto);

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyButtonPanel.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyButtonPanel.cs
@@ -187,6 +187,7 @@ namespace Sandbox.Game.Entities.Blocks
             checkAccess.Getter = (x) => x.AnyoneCanUse;
             checkAccess.Setter = (x, v) => x.AnyoneCanUse = v;
             checkAccess.EnableToggleAction();
+            checkAccess.EnableOnOffActions();
             MyTerminalControlFactory.AddControl(checkAccess);
 
             var toolbarButton = new MyTerminalControlButton<MyButtonPanel>("Open Toolbar", MySpaceTexts.BlockPropertyTitle_SensorToolbarOpen, MySpaceTexts.BlockPropertyDescription_SensorToolbarOpen,

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyButtonPanel.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyButtonPanel.cs
@@ -186,7 +186,7 @@ namespace Sandbox.Game.Entities.Blocks
             var checkAccess = new MyTerminalControlCheckbox<MyButtonPanel>("AnyoneCanUse", MySpaceTexts.BlockPropertyText_AnyoneCanUse, MySpaceTexts.BlockPropertyDescription_AnyoneCanUse);
             checkAccess.Getter = (x) => x.AnyoneCanUse;
             checkAccess.Setter = (x, v) => x.AnyoneCanUse = v;
-            checkAccess.EnableAction();
+            checkAccess.EnableToggleAction();
             MyTerminalControlFactory.AddControl(checkAccess);
 
             var toolbarButton = new MyTerminalControlButton<MyButtonPanel>("Open Toolbar", MySpaceTexts.BlockPropertyTitle_SensorToolbarOpen, MySpaceTexts.BlockPropertyDescription_SensorToolbarOpen,

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyGyro.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyGyro.cs
@@ -87,7 +87,7 @@ namespace Sandbox.Game.Entities
                 var gyroOverride = new MyTerminalControlCheckbox<MyGyro>("Override", MySpaceTexts.BlockPropertyTitle_GyroOverride, MySpaceTexts.BlockPropertyDescription_GyroOverride);
                 gyroOverride.Getter = (x) => x.GyroOverride;
                 gyroOverride.Setter = (x, v) => { x.SetGyroOverride(v); x.SyncObject.SendGyroOverrideRequest(v); };
-                gyroOverride.EnableAction();
+                gyroOverride.EnableToggleAction();
                 MyTerminalControlFactory.AddControl(gyroOverride);
 
                 // Pitch = X axis, Yaw = Y axis, Roll = Z axis

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyGyro.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyGyro.cs
@@ -88,6 +88,7 @@ namespace Sandbox.Game.Entities
                 gyroOverride.Getter = (x) => x.GyroOverride;
                 gyroOverride.Setter = (x, v) => { x.SetGyroOverride(v); x.SyncObject.SendGyroOverrideRequest(v); };
                 gyroOverride.EnableToggleAction();
+                gyroOverride.EnableOnOffActions();
                 MyTerminalControlFactory.AddControl(gyroOverride);
 
                 // Pitch = X axis, Yaw = Y axis, Roll = Z axis

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyLandingGear.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyLandingGear.cs
@@ -126,6 +126,7 @@ namespace Sandbox.Game.Entities.Cube
             autoLock.Getter = (b) => b.m_autoLock;
             autoLock.Setter = (b, v) => b.SyncObject.SendAutoLockChange(v);
             autoLock.EnableToggleAction();
+            autoLock.EnableOnOffActions();
             MyTerminalControlFactory.AddControl(autoLock);
 
             if (MyFakes.LANDING_GEAR_BREAKABLE)

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyLandingGear.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyLandingGear.cs
@@ -125,7 +125,7 @@ namespace Sandbox.Game.Entities.Cube
             var autoLock = new MyTerminalControlCheckbox<MyLandingGear>("Autolock", MySpaceTexts.BlockPropertyTitle_LandGearAutoLock, MySpaceTexts.Blank);
             autoLock.Getter = (b) => b.m_autoLock;
             autoLock.Setter = (b, v) => b.SyncObject.SendAutoLockChange(v);
-            autoLock.EnableAction();
+            autoLock.EnableToggleAction();
             MyTerminalControlFactory.AddControl(autoLock);
 
             if (MyFakes.LANDING_GEAR_BREAKABLE)

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
@@ -269,7 +269,7 @@ namespace Sandbox.Game.Entities.Cube
                     self.sync.ChangePerm(v);
                 };
             isPerm.Enabled = (self) => self.State==StateEnum.connected;
-            isPerm.EnableAction();
+            isPerm.EnableToggleAction();
             MyTerminalControlFactory.AddControl(isPerm);
 
             //--------------------------------------------------------------------------------------

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyLaserAntenna.cs
@@ -270,6 +270,7 @@ namespace Sandbox.Game.Entities.Cube
                 };
             isPerm.Enabled = (self) => self.State==StateEnum.connected;
             isPerm.EnableToggleAction();
+            isPerm.EnableOnOffActions();
             MyTerminalControlFactory.AddControl(isPerm);
 
             //--------------------------------------------------------------------------------------

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyMotorSuspension.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyMotorSuspension.cs
@@ -185,14 +185,14 @@ namespace Sandbox.Game.Entities.Cube
             var invertSteer = new MyTerminalControlCheckbox<MyMotorSuspension>("InvertSteering", MySpaceTexts.BlockPropertyTitle_Motor_InvertSteer, MySpaceTexts.BlockPropertyDescription_Motor_InvertSteer);
             invertSteer.Getter = (x) => x.InvertSteer;
             invertSteer.Setter = (x, v) => x.SyncObject.ChangeSlider(MySyncMotorSuspension.SliderEnum.InvertSteer, (v ? 1 : 0));
-            invertSteer.EnableAction();
+            invertSteer.EnableToggleAction();
             invertSteer.Enabled = (x) => x.m_constraint != null;
             MyTerminalControlFactory.AddControl(invertSteer);
 
             var propulsion = new MyTerminalControlCheckbox<MyMotorSuspension>("Propulsion", MySpaceTexts.BlockPropertyTitle_Motor_Propulsion, MySpaceTexts.BlockPropertyDescription_Motor_Propulsion);
             propulsion.Getter = (x) => x.Propulsion;
             propulsion.Setter = (x, v) => x.SyncObject.ChangePropulsion(v);
-            propulsion.EnableAction();
+            propulsion.EnableToggleAction();
             propulsion.Enabled = (x) => x.m_constraint != null;
             MyTerminalControlFactory.AddControl(propulsion);
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyMotorSuspension.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyMotorSuspension.cs
@@ -148,7 +148,7 @@ namespace Sandbox.Game.Entities.Cube
             var steering = new MyTerminalControlCheckbox<MyMotorSuspension>("Steering", MySpaceTexts.BlockPropertyTitle_Motor_Steering, MySpaceTexts.BlockPropertyDescription_Motor_Steering);
             steering.Getter = (x) => x.Steering;
             steering.Setter = (x, v) => x.SyncObject.ChangeSteering(v);
-            steering.EnableAction();
+            steering.EnableToggleAction();
             steering.Enabled = (x) => x.m_constraint != null;
             MyTerminalControlFactory.AddControl(steering);
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyOreDetector.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyOreDetector.cs
@@ -46,6 +46,7 @@ namespace Sandbox.Game.Entities.Cube
             broadcastUsingAntennas.Getter = (x) => x.m_oreDetectorComponent.BroadcastUsingAntennas;
             broadcastUsingAntennas.Setter = (x, v) => x.SyncObject.SendChangeOreDetector(v);
             broadcastUsingAntennas.EnableToggleAction();
+            broadcastUsingAntennas.EnableOnOffActions();
             MyTerminalControlFactory.AddControl(broadcastUsingAntennas);
         }
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyOreDetector.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyOreDetector.cs
@@ -45,7 +45,7 @@ namespace Sandbox.Game.Entities.Cube
             var broadcastUsingAntennas = new MyTerminalControlCheckbox<MyOreDetector>("BroadcastUsingAntennas", MySpaceTexts.BlockPropertyDescription_BroadcastUsingAntennas, MySpaceTexts.BlockPropertyDescription_BroadcastUsingAntennas);
             broadcastUsingAntennas.Getter = (x) => x.m_oreDetectorComponent.BroadcastUsingAntennas;
             broadcastUsingAntennas.Setter = (x, v) => x.SyncObject.SendChangeOreDetector(v);
-            broadcastUsingAntennas.EnableAction();
+            broadcastUsingAntennas.EnableToggleAction();
             MyTerminalControlFactory.AddControl(broadcastUsingAntennas);
         }
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenGenerator.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenGenerator.cs
@@ -79,6 +79,7 @@ namespace Sandbox.Game.Entities.Blocks
             autoRefill.Getter = (x) => x.m_autoRefill;
             autoRefill.Setter = (x, v) => x.m_autoRefill = v;
             autoRefill.EnableToggleAction();
+            autoRefill.EnableOnOffActions();
             MyTerminalControlFactory.AddControl(autoRefill);
         }
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenGenerator.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenGenerator.cs
@@ -50,11 +50,6 @@ namespace Sandbox.Game.Entities.Blocks
             }
         }
 
-        public bool AutoRefill
-        {
-            get { return m_autoRefill; }
-        }
-
         public MyPowerReceiver PowerReceiver
         {
             get;
@@ -81,9 +76,9 @@ namespace Sandbox.Game.Entities.Blocks
             MyTerminalControlFactory.AddControl(refillButton);
 
             var autoRefill = new MyTerminalControlCheckbox<MyOxygenGenerator>("Auto-Refill", MySpaceTexts.BlockPropertyTitle_AutoRefill, MySpaceTexts.BlockPropertyTitle_AutoRefill);
-            autoRefill.Getter = (x) => x.AutoRefill;
-            autoRefill.Setter = (x, v) => x.SyncObject.ChangeAutoRefill(v);
-            autoRefill.EnableAction();
+            autoRefill.Getter = (x) => x.m_autoRefill;
+            autoRefill.Setter = (x, v) => x.m_autoRefill = v;
+            autoRefill.EnableToggleAction();
             MyTerminalControlFactory.AddControl(autoRefill);
         }
 
@@ -322,7 +317,7 @@ namespace Sandbox.Game.Entities.Blocks
                                              : 0.0f;
         }
 
-        void m_inventory_ContentsChanged(MyInventoryBase obj)
+        void m_inventory_ContentsChanged(MyInventory obj)
         {
             RaisePropertiesChanged();
         }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenGenerator.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenGenerator.cs
@@ -50,6 +50,11 @@ namespace Sandbox.Game.Entities.Blocks
             }
         }
 
+        public bool AutoRefill
+        {
+            get { return m_autoRefill; }
+        }
+
         public MyPowerReceiver PowerReceiver
         {
             get;
@@ -76,10 +81,10 @@ namespace Sandbox.Game.Entities.Blocks
             MyTerminalControlFactory.AddControl(refillButton);
 
             var autoRefill = new MyTerminalControlCheckbox<MyOxygenGenerator>("Auto-Refill", MySpaceTexts.BlockPropertyTitle_AutoRefill, MySpaceTexts.BlockPropertyTitle_AutoRefill);
-            autoRefill.Getter = (x) => x.m_autoRefill;
-            autoRefill.Setter = (x, v) => x.m_autoRefill = v;
-            autoRefill.EnableToggleAction();
+            autoRefill.Getter = (x) => x.AutoRefill;
+            autoRefill.Setter = (x, v) => x.SyncObject.ChangeAutoRefill(v);
             autoRefill.EnableOnOffActions();
+            autoRefill.EnableToggleAction();
             MyTerminalControlFactory.AddControl(autoRefill);
         }
 
@@ -318,7 +323,7 @@ namespace Sandbox.Game.Entities.Blocks
                                              : 0.0f;
         }
 
-        void m_inventory_ContentsChanged(MyInventory obj)
+        void m_inventory_ContentsChanged(MyInventoryBase obj)
         {
             RaisePropertiesChanged();
         }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenTank.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenTank.cs
@@ -96,7 +96,7 @@ namespace Sandbox.Game.Entities.Blocks
             var autoRefill = new MyTerminalControlCheckbox<MyOxygenTank>("Auto-Refill", MySpaceTexts.BlockPropertyTitle_AutoRefill, MySpaceTexts.BlockPropertyTitle_AutoRefill);
             autoRefill.Getter = (x) => x.m_autoRefill;
             autoRefill.Setter = (x, v) => x.SyncObject.ChangeAutoRefill(v);
-            autoRefill.EnableAction();
+            autoRefill.EnableToggleAction();
             MyTerminalControlFactory.AddControl(autoRefill);
         }
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenTank.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenTank.cs
@@ -97,6 +97,7 @@ namespace Sandbox.Game.Entities.Blocks
             autoRefill.Getter = (x) => x.m_autoRefill;
             autoRefill.Setter = (x, v) => x.SyncObject.ChangeAutoRefill(v);
             autoRefill.EnableToggleAction();
+            autoRefill.EnableOnOffActions();
             MyTerminalControlFactory.AddControl(autoRefill);
         }
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyProjector.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyProjector.cs
@@ -132,7 +132,7 @@ namespace Sandbox.Game.Entities.Blocks
                 {
                     x.SyncObject.SendNewKeepProjection(v);
                 };
-            keepProjectionToggle.EnableAction();
+            keepProjectionToggle.EnableToggleAction();
             keepProjectionToggle.Enabled = (b) => b.IsProjecting();
             MyTerminalControlFactory.AddControl(keepProjectionToggle);
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyProjector.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyProjector.cs
@@ -134,6 +134,7 @@ namespace Sandbox.Game.Entities.Blocks
                 };
             keepProjectionToggle.EnableToggleAction();
             keepProjectionToggle.Enabled = (b) => b.IsProjecting();
+            keepProjectionToggle.EnableOnOffActions();
             MyTerminalControlFactory.AddControl(keepProjectionToggle);
 
             //ShowOnlyBuildable
@@ -145,6 +146,7 @@ namespace Sandbox.Game.Entities.Blocks
                 x.OnOffsetsChanged();
             };
             showOnlyBuildableBlockToggle.Enabled = (b) => b.IsProjecting();
+            showOnlyBuildableBlockToggle.EnableOnOffActions();
             MyTerminalControlFactory.AddControl(showOnlyBuildableBlockToggle);
 
             //Position

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyRadioAntenna.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyRadioAntenna.cs
@@ -163,7 +163,6 @@ namespace Sandbox.Game.Entities.Cube
             showShipName.Getter = (x) => x.ShowShipName;
             showShipName.Setter = (x, v) => x.RadioBroadcaster.SyncObject.SendChangeRadioAntennaDisplayName(v);
             showShipName.EnableToggleAction();
-            showShipName.EnableOnOffActions();
             MyTerminalControlFactory.AddControl(showShipName);
 
         }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyRadioAntenna.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyRadioAntenna.cs
@@ -155,13 +155,15 @@ namespace Sandbox.Game.Entities.Cube
             var enableBroadcast = new MyTerminalControlCheckbox<MyRadioAntenna>("EnableBroadCast", MySpaceTexts.Antenna_EnableBroadcast, MySpaceTexts.Antenna_EnableBroadcast);
             enableBroadcast.Getter = (x) => x.RadioBroadcaster.Enabled;
             enableBroadcast.Setter = (x, v) => x.RadioBroadcaster.SyncObject.SendChangeRadioAntennaRequest(x.RadioBroadcaster.BroadcastRadius, v);
-            enableBroadcast.EnableAction();
+            enableBroadcast.EnableToggleAction();
+            enableBroadcast.EnableCheckUncheckActions();
             MyTerminalControlFactory.AddControl(enableBroadcast);
 
             var showShipName = new MyTerminalControlCheckbox<MyRadioAntenna>("ShowShipName", MySpaceTexts.BlockPropertyTitle_ShowShipName, MySpaceTexts.BlockPropertyDescription_ShowShipName);
             showShipName.Getter = (x) => x.ShowShipName;
             showShipName.Setter = (x, v) => x.RadioBroadcaster.SyncObject.SendChangeRadioAntennaDisplayName(v);
-            showShipName.EnableAction();
+            showShipName.EnableToggleAction();
+            showShipName.EnableCheckUncheckActions();
             MyTerminalControlFactory.AddControl(showShipName);
 
         }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyRadioAntenna.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyRadioAntenna.cs
@@ -156,14 +156,14 @@ namespace Sandbox.Game.Entities.Cube
             enableBroadcast.Getter = (x) => x.RadioBroadcaster.Enabled;
             enableBroadcast.Setter = (x, v) => x.RadioBroadcaster.SyncObject.SendChangeRadioAntennaRequest(x.RadioBroadcaster.BroadcastRadius, v);
             enableBroadcast.EnableToggleAction();
-            enableBroadcast.EnableCheckUncheckActions();
+            enableBroadcast.EnableOnOffActions();
             MyTerminalControlFactory.AddControl(enableBroadcast);
 
             var showShipName = new MyTerminalControlCheckbox<MyRadioAntenna>("ShowShipName", MySpaceTexts.BlockPropertyTitle_ShowShipName, MySpaceTexts.BlockPropertyDescription_ShowShipName);
             showShipName.Getter = (x) => x.ShowShipName;
             showShipName.Setter = (x, v) => x.RadioBroadcaster.SyncObject.SendChangeRadioAntennaDisplayName(v);
             showShipName.EnableToggleAction();
-            showShipName.EnableCheckUncheckActions();
+            showShipName.EnableOnOffActions();
             MyTerminalControlFactory.AddControl(showShipName);
 
         }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyShipController.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyShipController.cs
@@ -167,6 +167,7 @@ namespace Sandbox.Game.Entities
             mainCockpit.Enabled = (x) => x.IsMainCockpitFree();
             mainCockpit.Visible = (x) => x.CanBeMainCockpit();
             mainCockpit.EnableToggleAction();
+            mainCockpit.EnableOnOffActions();
 
             MyTerminalControlFactory.AddControl(mainCockpit);
         }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyShipController.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyShipController.cs
@@ -108,7 +108,7 @@ namespace Sandbox.Game.Entities
                 controlThrusters.Setter = (x, v) => x.SyncObject.SetControlThrusters(v);
                 controlThrusters.Visible = (x) => x.m_enableShipControl;
                 controlThrusters.Enabled = (x) => x.IsMainCockpitFree();
-                var action = controlThrusters.EnableAction();
+                var action = controlThrusters.EnableToggleAction();
                 if (action != null)
                     action.Enabled = (x) => x.m_enableShipControl;
                 MyTerminalControlFactory.AddControl(controlThrusters);
@@ -118,7 +118,7 @@ namespace Sandbox.Game.Entities
                 controlWheels.Setter = (x, v) => x.SyncObject.SetControlWheels(v);
                 controlWheels.Visible = (x) => x.m_enableShipControl;
                 controlWheels.Enabled = (x) => x.GridWheels.WheelCount > 0 && x.IsMainCockpitFree();
-                action = controlWheels.EnableAction();
+                action = controlWheels.EnableToggleAction();
                 if (action != null)
                     action.Enabled = (x) => x.m_enableShipControl;
                 MyTerminalControlFactory.AddControl(controlWheels);
@@ -128,7 +128,7 @@ namespace Sandbox.Game.Entities
                 handBrake.Setter = (x, v) => x.CubeGrid.SyncObject.SetHandbrakeRequest(v);
                 handBrake.Visible = (x) => x.m_enableShipControl;
                 handBrake.Enabled = (x) => x.GridWheels.WheelCount > 0 && x.IsMainCockpitFree();
-                action = handBrake.EnableAction();
+                action = handBrake.EnableToggleAction();
                 if (action != null)
                     action.Enabled = (x) => x.m_enableShipControl;
                 MyTerminalControlFactory.AddControl(handBrake);
@@ -152,7 +152,7 @@ namespace Sandbox.Game.Entities
                 dampenersOverride.Setter = (x, v) => x.EnableDampingInternal(v, true);
                 dampenersOverride.Visible = (x) => x.m_enableShipControl;
 
-                var action = dampenersOverride.EnableAction();
+                var action = dampenersOverride.EnableToggleAction();
                 if (action != null)
                 {
                     action.Enabled = (x) => x.m_enableShipControl;// x.EnableShipControl;
@@ -166,7 +166,7 @@ namespace Sandbox.Game.Entities
             mainCockpit.Setter = (x, v) => x.SetMainCockpit(v);
             mainCockpit.Enabled = (x) => x.IsMainCockpitFree();
             mainCockpit.Visible = (x) => x.CanBeMainCockpit();
-            mainCockpit.EnableAction();
+            mainCockpit.EnableToggleAction();
 
             MyTerminalControlFactory.AddControl(mainCockpit);
         }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MySpaceBall.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MySpaceBall.cs
@@ -151,6 +151,7 @@ namespace Sandbox.Game.Entities
             enableBroadcast.Getter = (x) => x.RadioBroadcaster.Enabled;
             enableBroadcast.Setter = (x, v) => x.SyncObject.SendChangeBroadcastRequest(v);
             enableBroadcast.EnableToggleAction();
+            enableBroadcast.EnableOnOffActions();
             MyTerminalControlFactory.AddControl(enableBroadcast);
         }
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MySpaceBall.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MySpaceBall.cs
@@ -150,7 +150,7 @@ namespace Sandbox.Game.Entities
             var enableBroadcast = new MyTerminalControlCheckbox<MySpaceBall>("EnableBroadCast", MySpaceTexts.Antenna_EnableBroadcast, MySpaceTexts.Antenna_EnableBroadcast);
             enableBroadcast.Getter = (x) => x.RadioBroadcaster.Enabled;
             enableBroadcast.Setter = (x, v) => x.SyncObject.SendChangeBroadcastRequest(v);
-            enableBroadcast.EnableAction();
+            enableBroadcast.EnableToggleAction();
             MyTerminalControlFactory.AddControl(enableBroadcast);
         }
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyWarhead.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyWarhead.cs
@@ -125,7 +125,7 @@ namespace Sandbox.Game.Entities.Cube
                 MySpaceTexts.TerminalControlPanel_Warhead_SwitchTextArmed);
             safetyCheckbox.Getter = (x) => !x.IsArmed;
             safetyCheckbox.Setter = (x, v) => MySyncWarhead.SetArm(x, !v);
-            safetyCheckbox.EnableAction();
+            safetyCheckbox.EnableToggleAction();
             MyTerminalControlFactory.AddControl(safetyCheckbox);
 
             var detonateButton = new MyTerminalControlButton<MyWarhead>(

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlCheckbox.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlCheckbox.cs
@@ -101,17 +101,17 @@ namespace Sandbox.Game.Gui
             return action;
         }
 
-        public MyTerminalAction<TBlock> EnableCheckAction(string icon, StringBuilder name, StringBuilder onText, StringBuilder offText)
+        public MyTerminalAction<TBlock> EnableOnAction(string icon, StringBuilder name, StringBuilder onText, StringBuilder offText)
         {
-            var action = new MyTerminalAction<TBlock>(Id + "_Check", name, CheckAction, (x, r) => Writer(x, r, onText, offText), icon);
+            var action = new MyTerminalAction<TBlock>(Id + "_On", name, CheckAction, (x, r) => Writer(x, r, onText, offText), icon);
             AppendAction(action);
 
             return action;
         }
 
-        public MyTerminalAction<TBlock> EnableUncheckAction(string icon, StringBuilder name, StringBuilder onText, StringBuilder offText)
+        public MyTerminalAction<TBlock> EnableOffAction(string icon, StringBuilder name, StringBuilder onText, StringBuilder offText)
         {
-            var action = new MyTerminalAction<TBlock>(Id + "_Uncheck", name, UncheckAction, (x, r) => Writer(x, r, onText, offText), icon);
+            var action = new MyTerminalAction<TBlock>(Id + "_Off", name, UncheckAction, (x, r) => Writer(x, r, onText, offText), icon);
             AppendAction(action);
 
             return action;

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlCheckbox.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlCheckbox.cs
@@ -85,10 +85,34 @@ namespace Sandbox.Game.Gui
             result.Append(Getter(block) ? onText : offText);
         }
 
-        public MyTerminalAction<TBlock> EnableAction(string icon, StringBuilder name, StringBuilder onText, StringBuilder offText)
+        void AppendAction(MyTerminalAction<TBlock> action)
+        {
+            var arr = Actions ?? new MyTerminalAction<TBlock>[0];
+            Array.Resize(ref arr, arr.Length + 1);
+            arr[arr.Length - 1] = action;
+            Actions = arr;
+        }
+
+        public MyTerminalAction<TBlock> EnableToggleAction(string icon, StringBuilder name, StringBuilder onText, StringBuilder offText)
         {
             var action = new MyTerminalAction<TBlock>(Id, name, SwitchAction, (x, r) => Writer(x, r, onText, offText), icon);
-            Actions = new MyTerminalAction<TBlock>[] { action };
+            AppendAction(action);
+
+            return action;
+        }
+
+        public MyTerminalAction<TBlock> EnableCheckAction(string icon, StringBuilder name, StringBuilder onText, StringBuilder offText)
+        {
+            var action = new MyTerminalAction<TBlock>(Id + "_Check", name, CheckAction, (x, r) => Writer(x, r, onText, offText), icon);
+            AppendAction(action);
+
+            return action;
+        }
+
+        public MyTerminalAction<TBlock> EnableUncheckAction(string icon, StringBuilder name, StringBuilder onText, StringBuilder offText)
+        {
+            var action = new MyTerminalAction<TBlock>(Id + "_Uncheck", name, UncheckAction, (x, r) => Writer(x, r, onText, offText), icon);
+            AppendAction(action);
 
             return action;
         }

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlExtensions.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlExtensions.cs
@@ -81,19 +81,28 @@ namespace Sandbox.Game.Gui
             return checkbox.EnableToggleAction(MyTerminalActionIcons.TOGGLE, name, onText, offText);
         }
 
-        public static void EnableCheckUncheckActions<TBlock>(this MyTerminalControlCheckbox<TBlock> checkbox)
-            where TBlock : MyTerminalBlock
+        public static MyTerminalAction<TBlock> EnableToggleAction<TBlock>(this MyTerminalControlCheckbox<TBlock> onOff, string iconPath)
+           where TBlock : MyTerminalBlock
         {
-            EnableCheckUncheckActions(checkbox, MyTerminalActionIcons.ON, MyTerminalActionIcons.OFF);
+            StringBuilder name = CombineOnOff(onOff.Title, onOff.OnText, onOff.OffText);
+            StringBuilder onText = MyTexts.Get(onOff.OnText);
+            StringBuilder offText = MyTexts.Get(onOff.OffText);
+            return onOff.EnableToggleAction(iconPath, name, onText, offText);
         }
 
-        public static void EnableCheckUncheckActions<TBlock>(this MyTerminalControlCheckbox<TBlock> checkbox, string checkIcon, string uncheckIcon)
+        public static void EnableOnOffActions<TBlock>(this MyTerminalControlCheckbox<TBlock> checkbox)
             where TBlock : MyTerminalBlock
         {
-            StringBuilder checkText = MyTexts.Get(checkbox.OnText);
-            StringBuilder uncheckText = MyTexts.Get(checkbox.OffText);
-            checkbox.EnableCheckAction(checkIcon, GetTitle(checkbox.Title).Append(" ").Append(checkText), checkText, uncheckText);
-            checkbox.EnableUncheckAction(uncheckIcon, GetTitle(checkbox.Title).Append(" ").Append(uncheckText), checkText, uncheckText);
+            EnableOnOffActions(checkbox, MyTerminalActionIcons.ON, MyTerminalActionIcons.OFF);
+        }
+
+        public static void EnableOnOffActions<TBlock>(this MyTerminalControlCheckbox<TBlock> checkbox, string onIcon, string offIcon)
+            where TBlock : MyTerminalBlock
+        {
+            StringBuilder onText = MyTexts.Get(checkbox.OnText);
+            StringBuilder offText = MyTexts.Get(checkbox.OffText);
+            checkbox.EnableOnAction(onIcon, GetTitle(checkbox.Title).Append(" ").Append(onText), onText, offText);
+            checkbox.EnableOffAction(offIcon, GetTitle(checkbox.Title).Append(" ").Append(offText), onText, offText);
         }
 
         public static MyTerminalAction<TBlock> EnableToggleAction<TBlock>(this MyTerminalControlOnOffSwitch<TBlock> onOff)

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlExtensions.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlExtensions.cs
@@ -72,13 +72,28 @@ namespace Sandbox.Game.Gui
             return button.EnableAction(icon ?? MyTerminalActionIcons.TOGGLE, MyTexts.Get(title ?? button.Title), writer);
         }
 
-        public static MyTerminalAction<TBlock> EnableAction<TBlock>(this MyTerminalControlCheckbox<TBlock> checkbox)
+        public static MyTerminalAction<TBlock> EnableToggleAction<TBlock>(this MyTerminalControlCheckbox<TBlock> checkbox)
             where TBlock : MyTerminalBlock
         {
             StringBuilder name = CombineOnOff(checkbox.Title);
             StringBuilder onText = MyTexts.Get(checkbox.OnText);
             StringBuilder offText = MyTexts.Get(checkbox.OffText);
-            return checkbox.EnableAction(MyTerminalActionIcons.TOGGLE, name, onText, offText);
+            return checkbox.EnableToggleAction(MyTerminalActionIcons.TOGGLE, name, onText, offText);
+        }
+
+        public static void EnableCheckUncheckActions<TBlock>(this MyTerminalControlCheckbox<TBlock> checkbox)
+            where TBlock : MyTerminalBlock
+        {
+            EnableCheckUncheckActions(checkbox, MyTerminalActionIcons.ON, MyTerminalActionIcons.OFF);
+        }
+
+        public static void EnableCheckUncheckActions<TBlock>(this MyTerminalControlCheckbox<TBlock> checkbox, string checkIcon, string uncheckIcon)
+            where TBlock : MyTerminalBlock
+        {
+            StringBuilder checkText = MyTexts.Get(checkbox.OnText);
+            StringBuilder uncheckText = MyTexts.Get(checkbox.OffText);
+            checkbox.EnableCheckAction(checkIcon, GetTitle(checkbox.Title).Append(" ").Append(checkText), checkText, uncheckText);
+            checkbox.EnableUncheckAction(uncheckIcon, GetTitle(checkbox.Title).Append(" ").Append(uncheckText), checkText, uncheckText);
         }
 
         public static MyTerminalAction<TBlock> EnableToggleAction<TBlock>(this MyTerminalControlOnOffSwitch<TBlock> onOff)

--- a/Sources/SpaceEngineers.Game/Entities/Blocks/MyShipWelder.cs
+++ b/Sources/SpaceEngineers.Game/Entities/Blocks/MyShipWelder.cs
@@ -1,6 +1,5 @@
 ﻿using Sandbox.Common.ObjectBuilders;
 using Sandbox.Definitions;
-using Sandbox.Engine.Multiplayer;
 using Sandbox.Engine.Utils;
 using Sandbox.Game;
 using Sandbox.Game.Entities;
@@ -14,8 +13,7 @@ using Sandbox.Game.Multiplayer;
 using Sandbox.Game.Weapons;
 using Sandbox.Game.World;
 using Sandbox.Graphics.TransparentGeometry.Particles;
-using Sandbox.ModAPI;
-using SteamSDK;
+using Sandbox.ModAPI.Ingame;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -51,16 +49,14 @@ namespace SpaceEngineers.Game.Entities.Blocks
             if (MyFakes.ENABLE_WELDER_HELP_OTHERS)
             {
                 var helpOthersCheck = new MyTerminalControlCheckbox<MyShipWelder>("helpOthers", MySpaceTexts.ShipWelder_HelpOthers, MySpaceTexts.ShipWelder_HelpOthers);
-                helpOthersCheck.Getter = (x) => x.HelpOthers;
-                helpOthersCheck.Setter = (x, v) => x.SyncObject.ChangeHelpOthersMode(v);
-                helpOthersCheck.EnableAction();
+                helpOthersCheck.Getter = (x) => x.m_helpOthers;
+                helpOthersCheck.Setter = (x, v) =>
+                {
+                    x.m_helpOthers = v;
+                };
+                helpOthersCheck.EnableToggleAction();
                 MyTerminalControlFactory.AddControl(helpOthersCheck);
             }
-        }
-
-        public bool HelpOthers
-        {
-            get { return m_helpOthers; }
         }
 
         protected override bool CanInteractWithSelf
@@ -73,21 +69,9 @@ namespace SpaceEngineers.Game.Entities.Blocks
 
         public override void Init(MyObjectBuilder_CubeBlock objectBuilder, MyCubeGrid cubeGrid)
         {
-            SyncFlag = true;
-
             base.Init(objectBuilder, cubeGrid);
 
             m_missingComponents = new Dictionary<string, int>();
-
-            var builder = (MyObjectBuilder_ShipWelder)objectBuilder;
-            m_helpOthers = builder.HelpOthers;
-        }
-
-        public override MyObjectBuilder_CubeBlock GetObjectBuilderCubeBlock(bool copy = false)
-        {
-            var builder = (MyObjectBuilder_ShipWelder)base.GetObjectBuilderCubeBlock(copy);
-            builder.HelpOthers = m_helpOthers;
-            return builder;
         }
 
         protected override bool Activate(HashSet<MySlimBlock> targets)
@@ -133,7 +117,7 @@ namespace SpaceEngineers.Game.Entities.Blocks
                     block.MoveItemsToConstructionStockpile(Inventory);
 
                     // Allow welding only for blocks with deformations or unfinished/damaged blocks
-                    if ((block.HasDeformation || block.MaxDeformation > 0.0001f) || !block.IsFullIntegrity)
+                    if (block.MaxDeformation > 0.0f || !block.IsFullIntegrity)
                     {
                         float maxAllowedBoneMovement = WELDER_MAX_REPAIR_BONE_MOVEMENT_SPEED * MyShipGrinderConstants.GRINDER_COOLDOWN_IN_MILISECONDS * 0.001f;
                         block.IncreaseMountLevel(MySession.Static.WelderSpeedMultiplier * WELDER_AMOUNT_PER_SECOND * coefficient, OwnerId, Inventory, maxAllowedBoneMovement, m_helpOthers, IDModule.ShareMode);
@@ -319,60 +303,5 @@ namespace SpaceEngineers.Game.Entities.Blocks
             else
                 m_soundEmitter.PlaySingleSound(IDLE_SOUND, true);
         }
-
-        #region Sync
-        protected override MySyncEntity OnCreateSync()
-        {
-            return new MySyncShipWelder(this);
-        }
-
-        internal new MySyncShipWelder SyncObject
-        {
-            get
-            {
-                return (MySyncShipWelder)base.SyncObject;
-            }
-        }
-
-        [PreloadRequired]
-        internal class MySyncShipWelder : MySyncEntity
-        {
-            [MessageIdAttribute(8300, P2PMessageEnum.Reliable)]
-            protected struct ChangeHelperModeMsg : IEntityMessage
-            {
-                public long EntityId;
-                public long GetEntityId() { return EntityId; }
-
-                public BoolBlit HelpOthers;
-            }
-
-            private MyShipWelder m_shipWelder;
-
-            static MySyncShipWelder()
-            {
-                MySyncLayer.RegisterEntityMessage<MySyncShipWelder, ChangeHelperModeMsg>(OnHelpOthersChanged, MyMessagePermissions.Any);
-            }
-
-            public MySyncShipWelder(MyShipWelder shipWelder)
-                : base(shipWelder)
-            {
-                m_shipWelder = shipWelder;
-            }
-
-            public void ChangeHelpOthersMode(bool newHelperMode)
-            {
-                var msg = new ChangeHelperModeMsg();
-                msg.EntityId = m_shipWelder.EntityId;
-                msg.HelpOthers = newHelperMode;
-
-                Sync.Layer.SendMessageToAllAndSelf(ref msg);
-            }
-
-            private static void OnHelpOthersChanged(MySyncShipWelder syncObject, ref ChangeHelperModeMsg message, MyNetworkClient sender)
-            {
-                syncObject.m_shipWelder.m_helpOthers = message.HelpOthers;
-            }
-        }
-        #endregion
     }
 }

--- a/Sources/SpaceEngineers.Game/Entities/Blocks/MyShipWelder.cs
+++ b/Sources/SpaceEngineers.Game/Entities/Blocks/MyShipWelder.cs
@@ -55,6 +55,7 @@ namespace SpaceEngineers.Game.Entities.Blocks
                     x.m_helpOthers = v;
                 };
                 helpOthersCheck.EnableToggleAction();
+                helpOthersCheck.EnableOnOffActions();
                 MyTerminalControlFactory.AddControl(helpOthersCheck);
             }
         }

--- a/Sources/SpaceEngineers.Game/Entities/Blocks/MyShipWelder.cs
+++ b/Sources/SpaceEngineers.Game/Entities/Blocks/MyShipWelder.cs
@@ -1,5 +1,6 @@
 ﻿using Sandbox.Common.ObjectBuilders;
 using Sandbox.Definitions;
+using Sandbox.Engine.Multiplayer;
 using Sandbox.Engine.Utils;
 using Sandbox.Game;
 using Sandbox.Game.Entities;
@@ -13,7 +14,8 @@ using Sandbox.Game.Multiplayer;
 using Sandbox.Game.Weapons;
 using Sandbox.Game.World;
 using Sandbox.Graphics.TransparentGeometry.Particles;
-using Sandbox.ModAPI.Ingame;
+using Sandbox.ModAPI;
+using SteamSDK;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -49,15 +51,17 @@ namespace SpaceEngineers.Game.Entities.Blocks
             if (MyFakes.ENABLE_WELDER_HELP_OTHERS)
             {
                 var helpOthersCheck = new MyTerminalControlCheckbox<MyShipWelder>("helpOthers", MySpaceTexts.ShipWelder_HelpOthers, MySpaceTexts.ShipWelder_HelpOthers);
-                helpOthersCheck.Getter = (x) => x.m_helpOthers;
-                helpOthersCheck.Setter = (x, v) =>
-                {
-                    x.m_helpOthers = v;
-                };
-                helpOthersCheck.EnableToggleAction();
+                helpOthersCheck.Getter = (x) => x.HelpOthers;
+                helpOthersCheck.Setter = (x, v) => x.SyncObject.ChangeHelpOthersMode(v);
                 helpOthersCheck.EnableOnOffActions();
+                helpOthersCheck.EnableToggleAction();
                 MyTerminalControlFactory.AddControl(helpOthersCheck);
             }
+        }
+
+        public bool HelpOthers
+        {
+            get { return m_helpOthers; }
         }
 
         protected override bool CanInteractWithSelf
@@ -70,9 +74,21 @@ namespace SpaceEngineers.Game.Entities.Blocks
 
         public override void Init(MyObjectBuilder_CubeBlock objectBuilder, MyCubeGrid cubeGrid)
         {
+            SyncFlag = true;
+
             base.Init(objectBuilder, cubeGrid);
 
             m_missingComponents = new Dictionary<string, int>();
+
+            var builder = (MyObjectBuilder_ShipWelder)objectBuilder;
+            m_helpOthers = builder.HelpOthers;
+        }
+
+        public override MyObjectBuilder_CubeBlock GetObjectBuilderCubeBlock(bool copy = false)
+        {
+            var builder = (MyObjectBuilder_ShipWelder)base.GetObjectBuilderCubeBlock(copy);
+            builder.HelpOthers = m_helpOthers;
+            return builder;
         }
 
         protected override bool Activate(HashSet<MySlimBlock> targets)
@@ -118,7 +134,7 @@ namespace SpaceEngineers.Game.Entities.Blocks
                     block.MoveItemsToConstructionStockpile(Inventory);
 
                     // Allow welding only for blocks with deformations or unfinished/damaged blocks
-                    if (block.MaxDeformation > 0.0f || !block.IsFullIntegrity)
+                    if ((block.HasDeformation || block.MaxDeformation > 0.0001f) || !block.IsFullIntegrity)
                     {
                         float maxAllowedBoneMovement = WELDER_MAX_REPAIR_BONE_MOVEMENT_SPEED * MyShipGrinderConstants.GRINDER_COOLDOWN_IN_MILISECONDS * 0.001f;
                         block.IncreaseMountLevel(MySession.Static.WelderSpeedMultiplier * WELDER_AMOUNT_PER_SECOND * coefficient, OwnerId, Inventory, maxAllowedBoneMovement, m_helpOthers, IDModule.ShareMode);
@@ -304,5 +320,60 @@ namespace SpaceEngineers.Game.Entities.Blocks
             else
                 m_soundEmitter.PlaySingleSound(IDLE_SOUND, true);
         }
+
+        #region Sync
+        protected override MySyncEntity OnCreateSync()
+        {
+            return new MySyncShipWelder(this);
+        }
+
+        internal new MySyncShipWelder SyncObject
+        {
+            get
+            {
+                return (MySyncShipWelder)base.SyncObject;
+            }
+        }
+
+        [PreloadRequired]
+        internal class MySyncShipWelder : MySyncEntity
+        {
+            [MessageIdAttribute(8300, P2PMessageEnum.Reliable)]
+            protected struct ChangeHelperModeMsg : IEntityMessage
+            {
+                public long EntityId;
+                public long GetEntityId() { return EntityId; }
+
+                public BoolBlit HelpOthers;
+            }
+
+            private MyShipWelder m_shipWelder;
+
+            static MySyncShipWelder()
+            {
+                MySyncLayer.RegisterEntityMessage<MySyncShipWelder, ChangeHelperModeMsg>(OnHelpOthersChanged, MyMessagePermissions.Any);
+            }
+
+            public MySyncShipWelder(MyShipWelder shipWelder)
+                : base(shipWelder)
+            {
+                m_shipWelder = shipWelder;
+            }
+
+            public void ChangeHelpOthersMode(bool newHelperMode)
+            {
+                var msg = new ChangeHelperModeMsg();
+                msg.EntityId = m_shipWelder.EntityId;
+                msg.HelpOthers = newHelperMode;
+
+                Sync.Layer.SendMessageToAllAndSelf(ref msg);
+            }
+
+            private static void OnHelpOthersChanged(MySyncShipWelder syncObject, ref ChangeHelperModeMsg message, MyNetworkClient sender)
+            {
+                syncObject.m_shipWelder.m_helpOthers = message.HelpOthers;
+            }
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
This PR changes checkbox to behave same way as ON/OFF button in terminal property.
This allows 2 things
1) add and use _On/_Off action in PB
2) add and use On/Off action on checkboxes in Toolbar

checkboxes that should have On/Off still need add
MyTerminalCheckboxControl.EnableOnOffActions() upon construction of control object (which i added to some on my own)

It will also allow to have MyTerminalControlOnOffSwitch and MyTerminalControlCheckbox somewhat interchangeable (they have same methods now) ... difference between them will be mainly visual representation.