### PR TITLE
IMyAssembler: Added queue management functions

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyAssembler.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyAssembler.cs
@@ -21,11 +21,12 @@ namespace Sandbox.ModAPI.Ingame
         /// <param name="itemType">type of item, i.e. 'MyObjectBuilder_Component'</param>
         /// <param name="subtypeName">Shortname of component, i.e. SteelPlate, Reactor, MetalGrid, etc.</param>
         /// <param name="amount">Quantity of specified item to add to queue</param>
+        /// <param name="index">Index/Position item should be added to queue<br />-1 (default) adds to the end of queue<br />0 is first slot, 1 is second slot etc.</param>
         /// <returns>
         /// true - item added successfully
         /// false - item not added - probably because itemType or subtypeName are invalid
         /// </returns>
-        bool AddQueueItem(string itemType, string subtypeName, int amount);
+        bool AddQueueItem(string itemType, string subtypeName, int amount, int index = -1);
 
         /// <summary>
         /// Retrieves the number of items in the assembler queue
@@ -36,16 +37,16 @@ namespace Sandbox.ModAPI.Ingame
         /// <summary>
         /// Retrieves an item at index
         /// </summary>
-        /// <param name="idx"></param>
+        /// <param name="index"></param>
         /// <returns>IMyAssemblerQueueItem with details of queued item. Returns null if index is not valid.
         /// </returns>
-        IMyAssemblerQueueItem GetQueueItemAt(int idx);
+        IMyAssemblerQueueItem GetQueueItemAt(int index);
 
         /// <summary>
         /// Removes a queue item at specific index
         /// </summary>
         /// <param name="idx"></param>
-        void RemoveQueueItemAt(int idx);
+        void RemoveQueueItemAt(int index);
 
         /// <summary>
         /// Removes all items in the assembler queue

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyAssembler.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyAssembler.cs
@@ -61,7 +61,11 @@ namespace Sandbox.ModAPI.Ingame
         /// <returns>int - amount queued in total</returns>
         int CountQueueItems(string itemType, string subtypeName);
 
-
+        /// <summary>
+        /// True if assembler is unable to acquire components/items to process first in queue.
+        /// </summary>
+        bool MissingItems { get; }
+        
     }
 
     public interface IMyAssemblerQueueItem

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyAssembler.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyAssembler.cs
@@ -5,8 +5,68 @@ using System.Text;
 
 namespace Sandbox.ModAPI.Ingame
 {
+    /// <summary>
+    /// Interface for the assembler block
+    /// </summary>
     public interface IMyAssembler : IMyProductionBlock
     {
+        /// <summary>
+        /// True if assembler set to disassemble (read only)
+        /// </summary>
         bool DisassembleEnabled { get; }
+
+        /// <summary>
+        /// Adds an item to the assembler queue
+        /// </summary>
+        /// <param name="itemType">type of item, i.e. 'MyObjectBuilder_Component'</param>
+        /// <param name="subtypeName">Shortname of component, i.e. SteelPlate, Reactor, MetalGrid, etc.</param>
+        /// <param name="amount">Quantity of specified item to add to queue</param>
+        /// <returns>
+        /// true - item added successfully
+        /// false - item not added - probably because itemType or subtypeName are invalid
+        /// </returns>
+        bool AddQueueItem(string itemType, string subtypeName, int amount);
+
+        /// <summary>
+        /// Retrieves the number of items in the assembler queue
+        /// </summary>
+        /// <returns></returns>
+        int GetQueueCount();
+
+        /// <summary>
+        /// Retrieves an item at index
+        /// </summary>
+        /// <param name="idx"></param>
+        /// <returns>IMyAssemblerQueueItem with details of queued item. Returns null if index is not valid.
+        /// </returns>
+        IMyAssemblerQueueItem GetQueueItemAt(int idx);
+
+        /// <summary>
+        /// Removes a queue item at specific index
+        /// </summary>
+        /// <param name="idx"></param>
+        void RemoveQueueItemAt(int idx);
+
+        /// <summary>
+        /// Removes all items in the assembler queue
+        /// </summary>
+        void ClearQueue();
+
+        /// <summary>
+        /// Returns the total amount of an item in the queue
+        /// </summary>
+        /// <param name="itemType">the item type of item, i.e. MyObjectBuilder_Component</param>
+        /// <param name="subtypeName">The subtype name of item to count, i.e. SteelPlate</param>
+        /// <returns>int - amount queued in total</returns>
+        int CountQueueItems(string itemType, string subtypeName);
+
+
+    }
+
+    public interface IMyAssemblerQueueItem
+    {
+        int Amount { get; }
+        string Type { get; }
+        string SubtypeName { get; }
     }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
@@ -1146,17 +1146,17 @@ namespace Sandbox.Game.Entities.Cube
 
         }
 
-        bool Sandbox.ModAPI.Ingame.IMyAssembler.AddQueueItem(string itemType, string subtypeName, int amount)
+        bool Sandbox.ModAPI.Ingame.IMyAssembler.AddQueueItem(string itemType, string subtypeName, int amount, int index)
         {
             MyObjectBuilderType iType;
-            if (amount < 1 || !MyObjectBuilderType.TryParse(itemType, out iType))
+            if (amount < 1 || (index>0 && !m_queue.IsValidIndex(index-1)) || !MyObjectBuilderType.TryParse(itemType, out iType))
                 return false;
 
             var blueprint = MyDefinitionManager.Static.TryGetBlueprintDefinitionByResultId(new MyDefinitionId(iType, subtypeName));
             if (blueprint == null || !CanUseBlueprint(blueprint))
                 return false;
 
-            InsertQueueItemRequest(-1, blueprint, (VRage.MyFixedPoint)amount);
+            InsertQueueItemRequest(index, blueprint, (VRage.MyFixedPoint)amount);
 
             return true;
         }
@@ -1171,16 +1171,16 @@ namespace Sandbox.Game.Entities.Cube
             ClearQueue();
         }
 
-        Sandbox.ModAPI.Ingame.IMyAssemblerQueueItem Sandbox.ModAPI.Ingame.IMyAssembler.GetQueueItemAt(int idx)
+        Sandbox.ModAPI.Ingame.IMyAssemblerQueueItem Sandbox.ModAPI.Ingame.IMyAssembler.GetQueueItemAt(int index)
         {
-            if (m_queue.IsValidIndex(idx))
-                return new MyAssemblerQueueItem(m_queue[idx]);
+            if (m_queue.IsValidIndex(index))
+                return new MyAssemblerQueueItem(m_queue[index]);
             return null;
         }
-        void Sandbox.ModAPI.Ingame.IMyAssembler.RemoveQueueItemAt(int idx)
+        void Sandbox.ModAPI.Ingame.IMyAssembler.RemoveQueueItemAt(int index)
         {
-            if (m_queue.IsValidIndex(idx))
-                RemoveQueueItemRequest(idx);
+            if (m_queue.IsValidIndex(index))
+                RemoveQueueItemRequest(index);
         }
 
         int Sandbox.ModAPI.Ingame.IMyAssembler.CountQueueItems(string itemType, string subtypeName)

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
@@ -1196,6 +1196,16 @@ namespace Sandbox.Game.Entities.Cube
             return count;
         }
 
+        bool Sandbox.ModAPI.Ingame.IMyAssembler.MissingItems
+        {
+            get
+            {
+                if (!m_queue.IsValidIndex(0))
+                    return false;
+                return  CheckInventory(m_queue[0].Blueprint) == StateEnum.MissingItems;
+            }
+        }
+
         #endregion
 
         protected override float GetOperationalPowerConsumption()


### PR DESCRIPTION
Added the following functions:
```c# 
bool AddQueueItem(string itemType, string subtypeName, int amount);
int GetQueueCount();
IMyAssemblerQueueItem GetQueueItemAt(int idx);
void RemoveQueueItemAt(int idx);
void ClearQueue();
int CountQueueItems(string itemType, string subtypeName);
```
Added interface IMyAssemblerQueueItem

Added class MyAssemblerQueueItem to MyAssembler

Uses existing functions that are sync friendly for modifying the queue.

Compiles and tested OK.
In game test code: http://pastebin.com/ybWuqxTw

Closes #96