### PR TITLE
MyDoor: Fixed OpenRatio > 1

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyDoor.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyDoor.cs
@@ -111,7 +111,7 @@ namespace Sandbox.Game.Entities
 
         public float OpenRatio
         {
-            get { return m_currOpening; }
+            get { return m_currOpening/MaxOpen; }
         }
 
         static MyDoor()


### PR DESCRIPTION
MaxOpen could be greater that 1 and the default is 1.2. Therefore the
return value for OpenRatio could also be greater than 1.
This change makes OpenRatio return a percent.
Fixes #204