### PR TITLE
MyCharacter: Added a delay before damage from oxygen loss

### DIFF
--- a/Sources/Sandbox.Game/Definitions/MyCharacterDefinition.cs
+++ b/Sources/Sandbox.Game/Definitions/MyCharacterDefinition.cs
@@ -40,6 +40,7 @@ namespace Sandbox.Definitions
         public bool NeedsOxygen;
         public float OxygenConsumption;
         public float PressureLevelForLowDamage;
+        public int SecondsBeforeOxygenLossDamage;
         public float DamageAmountAtZeroPressure;
         public float OxygenCapacity;
         public string HelmetVariation;
@@ -143,6 +144,7 @@ namespace Sandbox.Definitions
             NeedsOxygen = builder.NeedsOxygen;
             OxygenConsumption = builder.OxygenConsumption;
             PressureLevelForLowDamage = builder.PressureLevelForLowDamage;
+            SecondsBeforeOxygenLossDamage = builder.SecondsBeforeOxygenLossDamage;
             DamageAmountAtZeroPressure = builder.DamageAmountAtZeroPressure;
             RagdollDataFile = builder.RagdollDataFile;
             HelmetVariation = builder.HelmetVariation;
@@ -256,6 +258,7 @@ namespace Sandbox.Definitions
             ob.NeedsOxygen = NeedsOxygen;
             ob.OxygenConsumption = OxygenConsumption;
             ob.PressureLevelForLowDamage = PressureLevelForLowDamage;
+            ob.SecondsBeforeOxygenLossDamage = SecondsBeforeOxygenLossDamage;
             ob.DamageAmountAtZeroPressure = DamageAmountAtZeroPressure;
             ob.OxygenCapacity = OxygenCapacity;
             ob.HelmetVariation = HelmetVariation;

--- a/Sources/Sandbox.Game/Game/Entities/Character/MyCharacter.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Character/MyCharacter.cs
@@ -439,6 +439,7 @@ namespace Sandbox.Game.Entities.Character
         }
         private float m_oldSuitOxygenLevel;
         bool m_needsOxygen;
+        private int m_timeOxygenRanOut = 0;
 
         public static readonly float LOW_OXYGEN_RATIO = 0.2f;
         MyHudNotification m_lowOxygenNotification;
@@ -1899,6 +1900,21 @@ namespace Sandbox.Game.Entities.Character
                 }
             }
 
+            // Prevent damage from no pressure/oxygen for X Seconds (Definition.SecondsBeforeOxygenLossDamage)
+            if (!noOxygenDamage && !lowOxygenDamage)
+                m_timeOxygenRanOut = 0; // Reset timer if we have oxygen
+
+            if (noOxygenDamage || lowOxygenDamage)
+            {
+                // Set timer if not already set.
+                if (m_timeOxygenRanOut == 0)
+                    m_timeOxygenRanOut = MySandboxGame.TotalGamePlayTimeInMilliseconds;
+
+                // If less than X seconds past since we should take damage, disable damage 
+                if (MySandboxGame.TotalGamePlayTimeInMilliseconds-m_timeOxygenRanOut<Definition.SecondsBeforeOxygenLossDamage*1000)
+                    noOxygenDamage = lowOxygenDamage = false;
+            }
+            
             if (noOxygenDamage)
             {
                 DoDamage(Definition.DamageAmountAtZeroPressure, MyDamageType.Environment, true);

--- a/Sources/SpaceEngineers/Content/Data/Characters.sbc
+++ b/Sources/SpaceEngineers/Content/Data/Characters.sbc
@@ -62,6 +62,7 @@
       </MaterialsDisabledIn1st>
       <OxygenConsumption>0.063</OxygenConsumption>
       <PressureLevelForLowDamage>0.5</PressureLevelForLowDamage>
+      <SecondsBeforeOxygenLossDamage>5</SecondsBeforeOxygenLossDamage>
       <DamageAmountAtZeroPressure>7</DamageAmountAtZeroPressure>
       <OxygenCapacity>60</OxygenCapacity>
       <NeedsOxygen>false</NeedsOxygen>
@@ -339,6 +340,7 @@
       </MaterialsDisabledIn1st>
       <OxygenConsumption>0.063</OxygenConsumption>
       <PressureLevelForLowDamage>0.5</PressureLevelForLowDamage>
+      <SecondsBeforeOxygenLossDamage>5</SecondsBeforeOxygenLossDamage>
       <DamageAmountAtZeroPressure>7</DamageAmountAtZeroPressure>
       <OxygenCapacity>60</OxygenCapacity>
       <NeedsOxygen>true</NeedsOxygen>

--- a/Sources/VRage.Game/ObjectBuilders/Definitions/MyObjectBuilder_CharacterDefinition.cs
+++ b/Sources/VRage.Game/ObjectBuilders/Definitions/MyObjectBuilder_CharacterDefinition.cs
@@ -236,6 +236,9 @@ namespace Sandbox.Common.ObjectBuilders.Definitions
         public float PressureLevelForLowDamage = 0.5f;
 
         [ProtoMember]
+        public int SecondsBeforeOxygenLossDamage = 5;
+
+        [ProtoMember]
         public float DamageAmountAtZeroPressure = 7f;
 
         [ProtoMember]


### PR DESCRIPTION
Added a delay based on a setting to prevent damage from oxygen loss for
a number of seconds. Default number of seconds is 5.

This is to imitate the fact that in real life you wouldn't take damage from oxygen loss/depressurisation straight away. Usually about 10 seconds of feeling quite uncomfortable come before any 'damage' (unless subject attempts to hold breath then lungs could rupture).

On another note, it should also resolve the issue of taking damage when opening a door within a pressurised structure.