### PR TITLE
Remove '.' from faction name, and '-' from antenna if antenna name is blank

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyRadioAntenna.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyRadioAntenna.cs
@@ -242,7 +242,9 @@ namespace Sandbox.Game.Entities.Cube
                 {
                     hudParams[0].Text.Clear();
                     hudParams[0].Text.Append(CubeGrid.DisplayName);
-                    hudParams[0].Text.Append(" - ").Append(this.CustomName);
+
+                    if (this.CustomName.Length > 0)
+                        hudParams[0].Text.Append(" - ").Append(this.CustomName);
                 }
 
                 m_hudParams.AddList(hudParams);

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyTerminalBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyTerminalBlock.cs
@@ -280,7 +280,9 @@ namespace Sandbox.Game.Entities.Cube
             if (!string.IsNullOrEmpty(GetOwnerFactionTag()))
             {
                 CustomNameWithFaction.Append(GetOwnerFactionTag());
-                CustomNameWithFaction.Append(".");
+                
+                if (CustomName.Length > 0)
+                    CustomNameWithFaction.Append(".");
             }
 
             CustomNameWithFaction.AppendStringBuilder(CustomName);


### PR DESCRIPTION
This cleans up the antenna HUD output if the antenna name is blank.

If ship name broadcasting is turned off, it will just show the faction name (eg. ~~PHX~~), not faction name and period (eg. ~~PHX.~~).

If ship name broadcasting is turned on, the '-' will only be shown if the antenna name is not (eg. ~~Ship name - Antenna~~). If blank, it will only show ship name (eg. ~~Ship name~~).