### PR TITLE
Fix SteamSDK path, solves build error on clean clone.

### DIFF
--- a/Sources/SpaceEngineers.Game/SpaceEngineers.Game.csproj
+++ b/Sources/SpaceEngineers.Game/SpaceEngineers.Game.csproj
@@ -47,7 +47,7 @@
   <ItemGroup>
     <Reference Include="SteamSDK, Version=0.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\3rd\SteamSDK\debug\x64\SteamSDK.dll</HintPath>
+      <HintPath>..\..\3rd\SteamSDK\debug\x86\SteamSDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Sources/SpaceEngineers.Game/SpaceEngineers.Game.csproj
+++ b/Sources/SpaceEngineers.Game/SpaceEngineers.Game.csproj
@@ -47,7 +47,7 @@
   <ItemGroup>
     <Reference Include="SteamSDK, Version=0.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\3rd\SteamSDK\Debug\x64\SteamSDK.dll</HintPath>
+      <HintPath>..\..\3rd\SteamSDK\debug\x64\SteamSDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Fixes #221 
Per the [discussion in #221](https://github.com/KeenSoftwareHouse/SpaceEngineers/issues/221#issuecomment-110015344), the SpaceEngineers.Game project file reference to SteamSDK needs to refer to the x86 version, which is the version we have.

a0c228 added this reference, but the path needs to read
```
debug\x86
```
instead of
```
Debug\x64
```