### PR TITLE
fix for exploding warhead projections

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyProjector.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyProjector.cs
@@ -735,6 +735,7 @@ namespace Sandbox.Game.Entities.Blocks
 
             foreach (var projectedBlock in ProjectedGrid.CubeBlocks)
             {
+                projectedBlock.UpdateForProjection();
                 Vector3 worldPosition = ProjectedGrid.GridIntegerToWorld(projectedBlock.Position);
                 Vector3I realPosition = CubeGrid.WorldToGridInteger(worldPosition);
                 var realBlock = CubeGrid.GetCubeBlock(realPosition);

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyWarhead.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyWarhead.cs
@@ -148,9 +148,7 @@ namespace Sandbox.Game.Entities.Cube
 
             m_countdownMs = ob.CountdownMs;
             m_isArmed = ob.IsArmed;
-
-            if (ob.IsCountingDown)
-                StartCountdown();
+            IsCountingDown = ob.IsCountingDown;
 
             this.IsWorkingChanged += MyWarhead_IsWorkingChanged;
         }
@@ -183,9 +181,9 @@ namespace Sandbox.Game.Entities.Cube
             {
                 StopCountdown();
             }
-            // restore countdown on finished block
-            if (IsWorking && IsCountingDown && !IsProjection)
+            else if (IsCountingDown && IsWorking && !IsProjection)
             {
+                IsCountingDown = false;
                 StartCountdown();
             }
 
@@ -439,13 +437,7 @@ namespace Sandbox.Game.Entities.Cube
         {
             base.OnAddedToScene(source);
 
-            if (IsCountingDown)
-            {
-                IsCountingDown = false;
-                StartCountdown();
-            }
-            else
-                UpdateEmissivity();
+            UpdateEmissivity();
         }
 
         public override void OnRemovedFromScene(object source)

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyWarhead.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyWarhead.cs
@@ -136,6 +136,9 @@ namespace Sandbox.Game.Entities.Cube
             MyTerminalControlFactory.AddControl(detonateButton);
         }
 
+        /// <summary>
+        /// indicates if loaded warhead is projection from blueprint or real warhead
+        /// </summary>
         public override void Init(MyObjectBuilder_CubeBlock objectBuilder, MyCubeGrid cubeGrid)
         {
             m_warheadDefinition = (MyWarheadDefinition)BlockDefinition;
@@ -145,6 +148,7 @@ namespace Sandbox.Game.Entities.Cube
 
             m_countdownMs = ob.CountdownMs;
             m_isArmed = ob.IsArmed;
+
             if (ob.IsCountingDown)
                 StartCountdown();
 
@@ -163,12 +167,28 @@ namespace Sandbox.Game.Entities.Cube
             return warheadBuilder;
         }
 
+        public override void UpdateForProjection()
+        {
+            base.UpdateForProjection();
+            bool wascountingdown = IsCountingDown;
+            /// stop countdown on projection to prevent "free" explosions
+            StopCountdown();
+            /// retain countdown state after disabling
+            IsCountingDown = wascountingdown;
+        }
+
         void MyWarhead_IsWorkingChanged(MyCubeBlock obj)
         {
             if (IsCountingDown && !IsWorking)
             {
                 StopCountdown();
             }
+            // restore countdown on finished block
+            if (IsWorking && IsCountingDown && !IsProjection)
+            {
+                StartCountdown();
+            }
+
             UpdateEmissivity();
         }
 

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBlock.cs
@@ -1132,6 +1132,24 @@ namespace Sandbox.Game.Entities
                 handler();
             }
         }
+
+        /// <summary>
+        /// indicates that block is only projection and not real entity
+        /// </summary>
+        public bool IsProjection
+        {
+            get
+            {
+                return SlimBlock.IsProjection;
+            }
+        }
+
+        /// <summary>
+        /// updates block, when projection is created, use this to remove adverse effects on projection, or disable unwanted functionality on projection
+        /// </summary>
+        public virtual void UpdateForProjection()
+        {
+        }
     }
 }
 

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MySlimBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MySlimBlock.cs
@@ -1660,5 +1660,21 @@ namespace Sandbox.Game.Entities.Cube
 				}
 			}
 		}
+
+        /// <summary>
+        /// indicates that block is projection, and not physical entity (for better checks inside block code)
+        /// </summary>
+        public bool IsProjection = false;
+
+        /// <summary>
+        /// this is called, when projection is created
+        /// </summary>
+        public void UpdateForProjection()
+        {
+            IsProjection = true;
+            /// call real block update
+            if (FatBlock != null)
+                FatBlock.UpdateForProjection();
+        }
     }
 }

--- a/Sources/VRage.Game/ObjectBuilders/MyObjectBuilder_Warhead.cs
+++ b/Sources/VRage.Game/ObjectBuilders/MyObjectBuilder_Warhead.cs
@@ -15,5 +15,12 @@ namespace Sandbox.Common.ObjectBuilders
 
         [ProtoMember]
         public bool IsCountingDown = false;
+
+        public override void SetupForProjector()
+        {
+            base.SetupForProjector();
+            IsCountingDown = false;
+            IsArmed = false;
+        }
     }
 }

--- a/Sources/VRage.Game/ObjectBuilders/MyObjectBuilder_Warhead.cs
+++ b/Sources/VRage.Game/ObjectBuilders/MyObjectBuilder_Warhead.cs
@@ -15,12 +15,5 @@ namespace Sandbox.Common.ObjectBuilders
 
         [ProtoMember]
         public bool IsCountingDown = false;
-
-        public override void SetupForProjector()
-        {
-            base.SetupForProjector();
-            IsCountingDown = false;
-            IsArmed = false;
-        }
     }
 }


### PR DESCRIPTION
disabled countdown and armed flag on warhead, when loaded in projector. (prevents exploding blueprints)
note - this is only for projector, to prevent "free" warhead explosions from projections.

if you save bp with wardhead countdown set, and then load it and paster into world, it will still explode.