### PR TITLE
Suspension additions fix and extra interface

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/IMyMotorSuspension.cs
+++ b/Sources/Sandbox.Common/ModAPI/IMyMotorSuspension.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sandbox.ModAPI
+{
+    public interface IMyMotorSuspension : Sandbox.ModAPI.Ingame.IMyMotorSuspension
+    {
+    }
+}

--- a/Sources/Sandbox.Common/Sandbox.Common.csproj
+++ b/Sources/Sandbox.Common/Sandbox.Common.csproj
@@ -238,6 +238,7 @@
     <Compile Include="ModAPI\Ingame\MyGridProgram.cs" />
     <Compile Include="ModAPI\Ingame\TerminalActionParameter.cs" />
     <Compile Include="ModAPI\IMyHudNotification.cs" />
+    <Compile Include="ModAPI\IMyMotorSuspension.cs" />
     <Compile Include="ModAPI\Interfaces\IMyDestroyableObject.cs" />
     <Compile Include="ModAPI\IMyIdentity.cs" />
     <Compile Include="ModAPI\Interfaces\IMyInventoryOwner.cs" />

--- a/Sources/Sandbox.Game/ModAPI/MyMotorSuspension_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/MyMotorSuspension_ModAPI.cs
@@ -8,7 +8,7 @@ using Havok;
 
 namespace Sandbox.Game.Entities.Cube
 {
-    partial class MyMotorSuspension : IMyMotorSuspension
+    partial class MyMotorSuspension : Sandbox.ModAPI.IMyMotorSuspension
     {
         bool IMyMotorSuspension.Steering { get { return Steering; } }
         bool IMyMotorSuspension.Propulsion { get { return Propulsion; } }
@@ -18,7 +18,7 @@ namespace Sandbox.Game.Entities.Cube
         float IMyMotorSuspension.Friction { get { return GetFrictionForTerminal(); } }
         float IMyMotorSuspension.Power { get { return GetPowerForTerminal(); } }
         float IMyMotorSuspension.Height { get { return GetHeightForTerminal(); } }
-        float IMyMotorSuspension.SteerAngle { get { return GetMaxSteerAngleForTerminal(); } }
+        float IMyMotorSuspension.SteerAngle { get { return m_steerAngle; } }
         float IMyMotorSuspension.MaxSteerAngle { get { return GetMaxSteerAngleForTerminal(); } }
         float IMyMotorSuspension.SteerSpeed { get { return GetSteerSpeedForTerminal(); } }
         float IMyMotorSuspension.SteerReturnSpeed { get { return GetSteerReturnSpeedForTerminal(); } }


### PR DESCRIPTION
Fixed the issue described here: https://github.com/KeenSoftwareHouse/SpaceEngineers/commit/b0f978dfe100bdf220b4031a17ab20f19001c23d#commitcomment-11657905

Also added ModAPI.IMyMotorSuspension interface mirror for modders to avoid the need to use `using Sandbox.ModAPI.Ingame` which causes conflicts with `using Sandbox.ModAPI`.