### PR TITLE
Allow a powered connector to lock to an unpowered one

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyShipConnector.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyShipConnector.cs
@@ -561,8 +561,9 @@ namespace Sandbox.Game.Entities.Cube
                             var otherPos = otherConnector.ConstraintPositionWorld();
                             float len = (otherPos - pos).LengthSquared();
 
-                            if (otherConnector.m_connectorMode == Mode.Connector && otherConnector.IsFunctional && (otherPos - pos).LengthSquared() < 0.35f)
+                            if (otherConnector.m_connectorMode == Mode.Connector && otherConnector.IsFunctional && otherConnector.Enabled && (otherPos - pos).LengthSquared() < 0.35f)
                             {
+                                MyHud.Notifications.Add(new MyHudNotificationDebug("Attach: " + CubeGrid.DisplayName));
                                 CreateConstraint(otherConnector);
                             }
                         }
@@ -580,8 +581,9 @@ namespace Sandbox.Game.Entities.Cube
             }
             else if (Sync.IsServer && !IsWorking)
             {
-                if (InConstraint && !Connected)
+                if (InConstraint && !Connected && (!IsFunctional || !Enabled || Enabled && !m_other.IsWorking))
                 {
+                    MyHud.Notifications.Add(new MyHudNotificationDebug("Detach: " + CubeGrid.DisplayName));
                     Detach();
                 }
             }
@@ -694,7 +696,7 @@ namespace Sandbox.Game.Entities.Cube
                 var connector = block.FatBlock as MyShipConnector;
                 if (connector.InConstraint) continue;
                 if (connector == thisConnector) continue;
-                if (!connector.IsWorking) continue;
+                if (!connector.IsFunctional || !connector.Enabled) continue;
                 if (!connector.FriendlyWithBlock(thisConnector)) continue;
 
                 m_tmpBlockSet.Clear();


### PR DESCRIPTION
This simple tweak allows a powered connector to establish a lock with an unpowered
one, as long as both connectors are switched on in the control panel.

Note that there several differences between this and initial (buggy) connector lock implementation:
1. The magnets disengage as soon as either connector is turned off. In contrast, the original implementation required BOTH connectors to be disabled in order to turn off magnetic attraction,
2. Only a powered connector may initiate a lock,
3. Finally, if both connectors lose power, the lock is immediately broken.

For detailed explanation on why this behaviour might be useful, see this thread on KSH forums:
http://forums.keenswh.com/threads/connect-to-unpowered-connectors-read-1st-post-before-voting.7361664/