### PR TITLE
Gui transparency

### DIFF
--- a/Sources/Sandbox.Game/Engine/Utils/MyConfig.cs
+++ b/Sources/Sandbox.Game/Engine/Utils/MyConfig.cs
@@ -89,6 +89,8 @@ namespace Sandbox.Engine.Utils
         readonly string FOLIAGE_DETAILS = "FoliageDetails";
         readonly string GRAPHICS_RENDERER = "GraphicsRenderer";
         readonly string ENABLE_VOICE_CHAT = "VoiceChat";
+        readonly string UI_TRANSPARENCY = "UiTransparency";
+        readonly string UI_BK_TRANSPARENCY = "UiBkTransparency";
 
         public MyConfig(string fileName)
             : base(fileName)
@@ -730,6 +732,18 @@ namespace Sandbox.Engine.Utils
             {
                 SetParameterValue(LAST_CHECKED_VERSION, value);
             }
+        }
+
+        public float UITransparency
+        {
+            get { return MyUtils.GetFloatFromString(GetParameterValue(UI_TRANSPARENCY), 1.0f); }
+            set { SetParameterValue(UI_TRANSPARENCY, value); }
+        }
+
+        public float UIBkTransparency
+        {
+            get { return MyUtils.GetFloatFromString(GetParameterValue(UI_BK_TRANSPARENCY), 1.0f); }
+            set { SetParameterValue(UI_BK_TRANSPARENCY, value); }
         }
 
         public bool HudWarnings

--- a/Sources/Sandbox.Game/Game/GUI/HudViewers/MyHudControlChat.cs
+++ b/Sources/Sandbox.Game/Game/GUI/HudViewers/MyHudControlChat.cs
@@ -36,10 +36,10 @@ namespace Sandbox.Game.GUI.HudViewers
             base.VisibleChanged += MyHudControlChat_VisibleChanged;
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
             UpdateText();
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
         }
 
         private void MyHudControlChat_VisibleChanged(object sender, bool isVisible)

--- a/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
+++ b/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
@@ -4060,6 +4060,26 @@ namespace Sandbox.Game.Localization
         public static readonly MyStringId ToolTipGameOptionsShowPlayerNames = MyStringId.GetOrCompute("ToolTipGameOptionsShowPlayerNames");
 
         ///<summary>
+        ///UI transparency
+        ///</summary>
+        public static readonly MyStringId ScreenOptionsGame_UITransparency = MyStringId.GetOrCompute("ScreenOptionsGame_UITransparency");
+
+        ///<summary>
+        ///Change transparency of UI dialogs.
+        ///</summary>
+        public static readonly MyStringId ToolTipGameOptionsUITransparency = MyStringId.GetOrCompute("ToolTipGameOptionsUITransparency");
+
+        ///<summary>
+        ///UI background transparency
+        ///</summary>
+        public static readonly MyStringId ScreenOptionsGame_UIBkTransparency = MyStringId.GetOrCompute("ScreenOptionsGame_UIBkTransparency");
+
+        ///<summary>
+        ///Change transparency of UI dialogs background.
+        ///</summary>
+        public static readonly MyStringId ToolTipGameOptionsUIBkTransparency = MyStringId.GetOrCompute("ToolTipGameOptionsUIBkTransparency");
+
+        ///<summary>
         ///Drop item
         ///</summary>
         public static readonly MyStringId ToolTipTerminalInventory_ThrowOut = MyStringId.GetOrCompute("ToolTipTerminalInventory_ThrowOut");

--- a/Sources/Sandbox.Game/Game/Screens/Helpers/MyGuiControlBlockInfo.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Helpers/MyGuiControlBlockInfo.cs
@@ -428,7 +428,7 @@ namespace Sandbox.Graphics.GUI
             }
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
             if (BlockInfo != null)
             {
@@ -504,7 +504,7 @@ namespace Sandbox.Graphics.GUI
                 m_blockIconPanel.BackgroundTexture = new MyGuiCompositeTexture(BlockInfo.BlockIcon);
             }
 
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
         }
     }
 }

--- a/Sources/Sandbox.Game/Game/Screens/Helpers/MyGuiControlToolbar.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Helpers/MyGuiControlToolbar.cs
@@ -88,13 +88,13 @@ namespace Sandbox.Game.Screens.Helpers
             base.Update();
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
             Color c = Color.White;
             if (MyToolbar.ColorMaskHSV != null)
                 c = (new Vector3(MyToolbar.ColorMaskHSV.X, MathHelper.Clamp(MyToolbar.ColorMaskHSV.Y + 0.8f, 0f, 1f), MathHelper.Clamp(MyToolbar.ColorMaskHSV.Z + 0.55f, 0f, 1f))).HSVtoColor();
             m_colorVariantPanel.ColorMask = c.ToVector4();//MyCubeBuilder.VariantColor;
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
         }
 
         protected override void OnSizeChanged()

--- a/Sources/Sandbox.Game/Game/Screens/MyGuiScreenOptionsGame.cs
+++ b/Sources/Sandbox.Game/Game/Screens/MyGuiScreenOptionsGame.cs
@@ -24,6 +24,8 @@ namespace Sandbox.Game.Gui
             public bool DisableHeadbob;
             public bool CompressSaveGames;
             public bool ShowPlayerNamesOnHud;
+            public float UITransparency;
+            public float UIBkTransparency;
         }
 
         MyGuiControlCombobox m_languageCombobox;
@@ -34,12 +36,14 @@ namespace Sandbox.Game.Gui
         MyGuiControlCheckbox m_disableHeadbobCheckbox;
         MyGuiControlCheckbox m_compressSavesCheckbox;
         MyGuiControlCheckbox m_showPlayerNamesCheckbox;
+        MyGuiControlSlider m_UITransparencySlider;
+        MyGuiControlSlider m_UIBkTransparencySlider;
         private MyGuiControlButton m_localizationWebButton;
         private MyGuiControlLabel m_localizationWarningLabel;
         private OptionsGameSettings m_settings = new OptionsGameSettings();
 
         public MyGuiScreenOptionsGame()
-            : base(new Vector2(0.5f, 0.5f), MyGuiConstants.SCREEN_BACKGROUND_COLOR, size: new Vector2(0.51f, 0.7f))
+            : base(new Vector2(0.5f, 0.5f), MyGuiConstants.SCREEN_BACKGROUND_COLOR, size: new Vector2(0.51f, 0.9f), backgroundTransition: MySandboxGame.Config.UIBkTransparency, guiTransition: MySandboxGame.Config.UITransparency)
         {
             EnabledBackgroundFade = true;
 
@@ -197,6 +201,34 @@ namespace Sandbox.Game.Gui
             };
             m_showPlayerNamesCheckbox.IsCheckedChanged += checkboxChanged;
 
+            rowIndex++;
+            var UITransparencyLabel = new MyGuiControlLabel(text: MyTexts.GetString(MySpaceTexts.ScreenOptionsGame_UITransparency))
+            {
+                Position = controlsOriginLeft + rowIndex * controlsDelta,
+                OriginAlign = leftAlign
+            };
+            rowIndex++;
+            m_UITransparencySlider = new MyGuiControlSlider(toolTip: MyTexts.GetString(MySpaceTexts.ToolTipGameOptionsUITransparency), minValue: 0, maxValue: 1.0f, defaultValue: 1.0f)
+            {
+                Position = controlsOriginRight + rowIndex * controlsDelta,
+                OriginAlign = rightAlign,
+            };
+            m_UITransparencySlider.ValueChanged += sliderChanged;
+
+            rowIndex++;
+            var UIBkTransparencyLabel = new MyGuiControlLabel(text: MyTexts.GetString(MySpaceTexts.ScreenOptionsGame_UIBkTransparency))
+            {
+                Position = controlsOriginLeft + rowIndex * controlsDelta,
+                OriginAlign = leftAlign
+            };
+            rowIndex++;
+            m_UIBkTransparencySlider = new MyGuiControlSlider(toolTip: MyTexts.GetString(MySpaceTexts.ToolTipGameOptionsUIBkTransparency), minValue: 0, maxValue: 1.0f, defaultValue: 1.0f)
+            {
+                Position = controlsOriginRight + rowIndex * controlsDelta,
+                OriginAlign = rightAlign,
+            };
+            m_UIBkTransparencySlider.ValueChanged += sliderChanged;
+
             //  Buttons OK and CANCEL
             var buttonOk = new MyGuiControlButton(text: MyTexts.Get(MySpaceTexts.Ok), onButtonClick: OnOkClick);
             var buttonCancel = new MyGuiControlButton(text: MyTexts.Get(MySpaceTexts.Cancel), onButtonClick: OnCancelClick);
@@ -225,6 +257,10 @@ namespace Sandbox.Game.Gui
             Controls.Add(m_compressSavesCheckbox);
             Controls.Add(showPlayerNamesOnHudLabel);
             Controls.Add(m_showPlayerNamesCheckbox);
+            Controls.Add(UITransparencyLabel);
+            Controls.Add(m_UITransparencySlider);
+            Controls.Add(UIBkTransparencyLabel);
+            Controls.Add(m_UIBkTransparencySlider);
             Controls.Add(buttonOk);
             Controls.Add(buttonCancel);
 
@@ -249,6 +285,14 @@ namespace Sandbox.Game.Gui
                 m_settings.CompressSaveGames = obj.IsChecked;
             else if (obj == m_showPlayerNamesCheckbox)
                 m_settings.ShowPlayerNamesOnHud = obj.IsChecked;
+        }
+
+        private void sliderChanged(MyGuiControlSlider obj)
+        {
+            if (obj == m_UITransparencySlider)
+                m_settings.UITransparency = obj.Value;
+            else if (obj == m_UIBkTransparencySlider)
+                m_settings.UIBkTransparency = obj.Value;
         }
 
         void m_buildingModeCombobox_ItemSelected()
@@ -307,6 +351,8 @@ namespace Sandbox.Game.Gui
                 m_disableHeadbobCheckbox.IsChecked = MySandboxGame.Config.DisableHeadbob;
                 m_compressSavesCheckbox.IsChecked = MySandboxGame.Config.CompressSaveGames;
                 m_showPlayerNamesCheckbox.IsChecked = MySandboxGame.Config.ShowPlayerNamesOnHud;
+                m_UITransparencySlider.Value = MySandboxGame.Config.UITransparency;
+                m_UIBkTransparencySlider.Value = MySandboxGame.Config.UIBkTransparency;
             }
             else
             {
@@ -318,6 +364,8 @@ namespace Sandbox.Game.Gui
                 m_disableHeadbobCheckbox.IsChecked = m_settings.DisableHeadbob;
                 m_compressSavesCheckbox.IsChecked = m_settings.CompressSaveGames;
                 m_showPlayerNamesCheckbox.IsChecked = m_settings.ShowPlayerNamesOnHud;
+                m_UITransparencySlider.Value = m_settings.UITransparency;
+                m_UIBkTransparencySlider.Value = m_settings.UIBkTransparency;
             }
         }
 
@@ -332,6 +380,8 @@ namespace Sandbox.Game.Gui
             MySandboxGame.Config.DisableHeadbob = m_disableHeadbobCheckbox.IsChecked;
             MySandboxGame.Config.CompressSaveGames = m_compressSavesCheckbox.IsChecked;
             MySandboxGame.Config.ShowPlayerNamesOnHud = m_showPlayerNamesCheckbox.IsChecked;
+            MySandboxGame.Config.UITransparency = m_UITransparencySlider.Value;
+            MySandboxGame.Config.UIBkTransparency = m_UIBkTransparencySlider.Value;
             MySandboxGame.Config.Save();
         }
 

--- a/Sources/Sandbox.Game/Game/Screens/MyGuiScreenOptionsGame.cs
+++ b/Sources/Sandbox.Game/Game/Screens/MyGuiScreenOptionsGame.cs
@@ -208,7 +208,7 @@ namespace Sandbox.Game.Gui
                 OriginAlign = leftAlign
             };
             rowIndex++;
-            m_UITransparencySlider = new MyGuiControlSlider(toolTip: MyTexts.GetString(MySpaceTexts.ToolTipGameOptionsUITransparency), minValue: 0, maxValue: 1.0f, defaultValue: 1.0f)
+            m_UITransparencySlider = new MyGuiControlSlider(toolTip: MyTexts.GetString(MySpaceTexts.ToolTipGameOptionsUITransparency), minValue: 0.1f, maxValue: 1.0f, defaultValue: 1.0f)
             {
                 Position = controlsOriginRight + rowIndex * controlsDelta,
                 OriginAlign = rightAlign,
@@ -290,9 +290,15 @@ namespace Sandbox.Game.Gui
         private void sliderChanged(MyGuiControlSlider obj)
         {
             if (obj == m_UITransparencySlider)
+            {
                 m_settings.UITransparency = obj.Value;
+                m_guiTransition = obj.Value;
+            }
             else if (obj == m_UIBkTransparencySlider)
+            {
                 m_settings.UIBkTransparency = obj.Value;
+                m_backgroundTransition = obj.Value;
+            }
         }
 
         void m_buildingModeCombobox_ItemSelected()

--- a/Sources/Sandbox.Game/Game/Screens/MyGuiScreenToolbarConfigBase.cs
+++ b/Sources/Sandbox.Game/Game/Screens/MyGuiScreenToolbarConfigBase.cs
@@ -223,7 +223,7 @@ namespace Sandbox.Game.Gui
         #region constructros + overrides
 
         public MyGuiScreenToolbarConfigBase(int scrollOffset = 0, MyCubeBlock owner = null)
-            : base(new Vector2(0.5f, 0.5f), MyGuiConstants.SCREEN_BACKGROUND_COLOR)
+            : base(new Vector2(0.5f, 0.5f), MyGuiConstants.SCREEN_BACKGROUND_COLOR, backgroundTransition: MySandboxGame.Config.UIBkTransparency, guiTransition: MySandboxGame.Config.UITransparency)
         {
             MySandboxGame.Log.WriteLine("MyGuiScreenCubeBuilder.ctor START");
 

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/MyGuiScreenTerminal.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/MyGuiScreenTerminal.cs
@@ -101,7 +101,7 @@ namespace Sandbox.Game.Gui
         private MyGuiScreenTerminal() :
             base(position: new Vector2(0.5f, 0.5f),
                  backgroundColor: MyGuiConstants.SCREEN_BACKGROUND_COLOR,
-                 size: new Vector2(0.99f, 0.9f))
+                 size: new Vector2(0.99f, 0.9f), backgroundTransition: MySandboxGame.Config.UIBkTransparency, guiTransition: MySandboxGame.Config.UITransparency)
         {
             EnabledBackgroundFade = true;
             m_closeHandler = OnInteractedClose;

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlBase.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlBase.cs
@@ -569,10 +569,10 @@ namespace Sandbox.Graphics.GUI
 
         #region Virtuals
 
-        public virtual void Draw(float transitionAlpha)
+        public virtual void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            DrawBackground(transitionAlpha);
-            DrawElements(transitionAlpha);
+            DrawBackground(backgroundTransitionAlpha);
+            DrawElements(transitionAlpha, backgroundTransitionAlpha);
             DrawBorder(transitionAlpha);
         }
 
@@ -907,14 +907,14 @@ namespace Sandbox.Graphics.GUI
             }
         }
 
-        protected virtual void DrawElements(float transitionAlpha)
+        protected virtual void DrawElements(float transitionAlpha, float backgroundTransitionAlpha)
         {
             foreach (MyGuiControlBase element in Elements.GetVisibleControls())
             {
                 if (element.GetExclusiveInputHandler() == element)
                     continue;
 
-                element.Draw(transitionAlpha);
+                element.Draw(transitionAlpha, backgroundTransitionAlpha);
             }
         }
 

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlBlockProperty.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlBlockProperty.cs
@@ -87,9 +87,9 @@ namespace Sandbox.Graphics.GUI
             //base.OnRemoving();
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
         }
 
         public override MyGuiControlBase HandleInput()

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlButton.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlButton.cs
@@ -353,9 +353,9 @@ namespace Sandbox.Graphics.GUI
                 ButtonClicked(this);
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, transitionAlpha);
 
             bool isNotImplementedForbidenOrDisabled = !m_implementedFeature || !Enabled;
             Vector4 backgroundColor, textColor;

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlCheckbox.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlCheckbox.cs
@@ -153,9 +153,9 @@ namespace Sandbox.Graphics.GUI
             VisualStyle = controlBuilder.VisualStyle;
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, transitionAlpha);
             var iconTexture = (HasHighlight) ? m_icon.Highlight : m_icon.Normal;
             if (!string.IsNullOrEmpty(iconTexture))
             {

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlColor.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlColor.cs
@@ -130,7 +130,7 @@ namespace Sandbox.Graphics.GUI
                 font: font);
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
             var position = GetPositionAbsoluteTopRight();
             var size = new Vector2(m_BSlider.Size.X, m_textLabel.Size.Y);
@@ -140,7 +140,7 @@ namespace Sandbox.Graphics.GUI
                 size,
                 ApplyColorMaskModifiers(m_color.ToVector4(), true, transitionAlpha),
                 MyGuiDrawAlignEnum.HORISONTAL_RIGHT_AND_VERTICAL_TOP);
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
 
             position.X -= size.X;
             MyGuiManager.DrawBorders(position, size, Color.White, BorderSize);

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlCombobox.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlCombobox.cs
@@ -900,10 +900,10 @@ namespace Sandbox.Graphics.GUI
         ///     c. draw the display items
         ///     d. disable stencil
         /// </summary>
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
             // In case of listbox mode, before calling parent's draw, reset background color, because it will draw unwanted texture for first item in list(texture, that is used normally for closed combobox)
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, transitionAlpha);
 
             if (m_selected != null)
                 DrawSelectedItemText(transitionAlpha);

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlCompositePanel.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlCompositePanel.cs
@@ -44,9 +44,9 @@ namespace Sandbox.Graphics.GUI
         }
         #endregion
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            BackgroundTexture.Draw(GetPositionAbsoluteTopLeft(), Size, ApplyColorMaskModifiers(ColorMask, Enabled, transitionAlpha));
+            BackgroundTexture.Draw(GetPositionAbsoluteTopLeft(), Size, ApplyColorMaskModifiers(ColorMask, Enabled, backgroundTransitionAlpha));
             DrawBorder(transitionAlpha);
         }
 

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlContextMenu.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlContextMenu.cs
@@ -265,10 +265,10 @@ namespace Sandbox.Graphics.GUI
             if (m_itemsList.Position.Y + m_itemsList.Size.Y >= 1) m_itemsList.Position = new Vector2(m_itemsList.Position.X, 1.0f - m_itemsList.Size.Y);
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
-            m_itemsList.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
+            m_itemsList.Draw(transitionAlpha, backgroundTransitionAlpha);
         }
 
         private bool IsEnoughDelay(MyContextMenuKeys key, int forcedDelay)

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlGrid.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlGrid.cs
@@ -536,11 +536,11 @@ namespace Sandbox.Graphics.GUI
         }
         #endregion
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
             RefreshItemsRectangle();
-            DrawItemBackgrounds(transitionAlpha);
+            DrawItemBackgrounds(backgroundTransitionAlpha);
             DrawItems(transitionAlpha);
             DrawItemTexts(transitionAlpha);
             //DebugDraw();

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlGridDragAndDrop.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlGridDragAndDrop.cs
@@ -91,7 +91,7 @@ namespace Sandbox.Graphics.GUI
             return IsActive();
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
             //base.Draw();
 
@@ -103,7 +103,7 @@ namespace Sandbox.Graphics.GUI
                     MyGuiManager.DrawSpriteBatch(MyGuiConstants.BLANK_TEXTURE,
                         MyGuiManager.MouseCursorPosition,
                         Size,
-                        ApplyColorMaskModifiers(ColorMask * new Color(50, 66, 70, 255).ToVector4(), true, transitionAlpha), MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER);
+                        ApplyColorMaskModifiers(ColorMask * new Color(50, 66, 70, 255).ToVector4(), true, backgroundTransitionAlpha), MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER);
                 }
 
                 Vector2 itemPosition = MyGuiManager.MouseCursorPosition - Size / 2.0f;

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlLabel.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlLabel.cs
@@ -172,9 +172,9 @@ namespace Sandbox.Graphics.GUI
             return objectBuilder;
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
 
             // String builder has priority when drawing.
             float maxWidth = AutoEllipsis ? Size.X : float.PositiveInfinity;

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlList.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlList.cs
@@ -130,17 +130,17 @@ namespace Sandbox.Graphics.GUI
         }
         #endregion
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
             var topLeft = GetPositionAbsoluteTopLeft();
             m_styleDef.Texture.Draw(topLeft, Size,
-                ApplyColorMaskModifiers(ColorMask, Enabled, transitionAlpha));
+                ApplyColorMaskModifiers(ColorMask, Enabled, backgroundTransitionAlpha));
 
             var scissor = m_itemsRectangle;
             scissor.Position += topLeft;
             using (MyGuiManager.UsingScissorRectangle(ref scissor))
             {
-                base.Draw(transitionAlpha);
+                base.Draw(transitionAlpha, backgroundTransitionAlpha);
             }
 
             if (m_showScrollbar)

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlListbox.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlListbox.cs
@@ -403,13 +403,13 @@ namespace Sandbox.Graphics.GUI
             return captureInput;
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
             Debug.Assert(m_visibleRowIndexOffset >= 0);
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
             var positionTopLeft = GetPositionAbsoluteTopLeft();
 
-            m_styleDef.Texture.Draw(positionTopLeft, Size, ApplyColorMaskModifiers(ColorMask, Enabled, transitionAlpha));
+            m_styleDef.Texture.Draw(positionTopLeft, Size, ApplyColorMaskModifiers(ColorMask, Enabled, backgroundTransitionAlpha));
 
             var position = positionTopLeft + new Vector2(m_itemsRectangle.X, m_itemsRectangle.Y);
             int index = m_visibleRowIndexOffset;

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlMultilineText.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlMultilineText.cs
@@ -331,9 +331,9 @@ namespace Sandbox.Graphics.GUI
             }
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
             var textArea = new MyRectangle2D(Vector2.Zero, Size);
             textArea.LeftTop += GetPositionAbsoluteTopLeft();
             Vector2 carriageOffset = GetCarriageOffset(CarriagePositionIndex);
@@ -347,7 +347,7 @@ namespace Sandbox.Graphics.GUI
 
             using (MyGuiManager.UsingScissorRectangle(ref scissor))
             {
-                DrawSelectionBackgrounds(textArea, transitionAlpha);
+                DrawSelectionBackgrounds(textArea, backgroundTransitionAlpha);
                 DrawText(m_scrollbar.Value);
 
 

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlParent.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlParent.cs
@@ -58,9 +58,9 @@ namespace Sandbox.Graphics.GUI
 
         #region Overriden methods
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
 
             foreach (MyGuiControlBase control in Controls.GetVisibleControls())
             {
@@ -69,7 +69,7 @@ namespace Sandbox.Graphics.GUI
                     continue;
                 }
 
-                control.Draw(transitionAlpha);
+                control.Draw(transitionAlpha, backgroundTransitionAlpha);
             }
         }
 

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlProgressBar.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlProgressBar.cs
@@ -55,9 +55,9 @@ namespace Sandbox.Graphics.GUI
             return ob;
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
 
             // draw progress bar
             var progressFillSize = Size * (new Vector2(Value, 1.0f));

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlRadioButton.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlRadioButton.cs
@@ -303,9 +303,9 @@ namespace Sandbox.Graphics.GUI
             return ret;
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
 
             Vector2 topLeft = Vector2.Zero;
             if (Icon.HasValue || (Text != null && Text.Length > 0))

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlRotatingWheel.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlRotatingWheel.cs
@@ -41,9 +41,9 @@ namespace Sandbox.Graphics.GUI
             base.Update();
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
 
             Vector2 rotatingSize = MyGuiManager.GetNormalizedSize(new Vector2(256,256), m_wheelScale);
             Vector2 rotatingPosition = GetPositionAbsolute() + new Vector2(rotatingSize.X / 2.0f, rotatingSize.Y / 2.0f);

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlScrollablePanel.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlScrollablePanel.cs
@@ -155,9 +155,9 @@ namespace Sandbox.Graphics.GUI
             return res;
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
 
             var scrollbarMask = ApplyColorMaskModifiers(ColorMask, Enabled, transitionAlpha);
             if (m_scrollbarV != null)
@@ -175,13 +175,13 @@ namespace Sandbox.Graphics.GUI
             //DebugDraw();
         }
 
-        protected override void DrawElements(float transitionAlpha)
+        protected override void DrawElements(float transitionAlpha, float backgroundTransitionAlpha)
         {
             var scissor = m_scrolledArea;
             scissor.Position += GetPositionAbsoluteTopLeft();
             using (MyGuiManager.UsingScissorRectangle(ref scissor))
             {
-                base.DrawElements(transitionAlpha);
+                base.DrawElements(transitionAlpha, backgroundTransitionAlpha);
             }
         }
 

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlSeparatorList.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlSeparatorList.cs
@@ -65,7 +65,7 @@ namespace Sandbox.Graphics.GUI
 
         #endregion
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
             var center = GetPositionAbsoluteCenter();
 

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlSlider.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlSlider.cs
@@ -252,9 +252,9 @@ namespace Sandbox.Graphics.GUI
             return ret;
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
 
             m_railTexture.Draw(
                 GetPositionAbsoluteTopLeft(),
@@ -262,7 +262,7 @@ namespace Sandbox.Graphics.GUI
                 ApplyColorMaskModifiers(ColorMask, Enabled, transitionAlpha),
                 textureScale: DebugScale);
             DrawThumb(transitionAlpha);
-            m_label.Draw(transitionAlpha);
+            m_label.Draw(transitionAlpha, backgroundTransitionAlpha);
         }
 
         protected override void OnSizeChanged()

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlTabControl.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlTabControl.cs
@@ -171,7 +171,7 @@ namespace Sandbox.Graphics.GUI
             return ob;
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
             //draw buttons on head with texts
             var normalTexture = MyGuiConstants.TEXTURE_BUTTON_DEFAULT_NORMAL;
@@ -195,7 +195,7 @@ namespace Sandbox.Graphics.GUI
                 var font              = (isEnabled && isHighlight) ? MyFontEnum.White : MyFontEnum.Blue;
 
                 // Draw background texture
-                texture.Draw(currentPos, TabButtonSize, colorMaskModified, m_tabButtonScale);
+                texture.Draw(currentPos, TabButtonSize, ApplyColorMaskModifiers(ColorMask, isEnabled, transitionAlpha), m_tabButtonScale);
                 StringBuilder text = currentTab.Text;
                 if (text != null)
                 {
@@ -212,7 +212,7 @@ namespace Sandbox.Graphics.GUI
                 pos++;
             }
 
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
         }
       
         public override MyGuiControlBase HandleInput()

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlTable.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlTable.cs
@@ -442,14 +442,14 @@ namespace Sandbox.Graphics.GUI
                 m_scrollBar.Value = selectedIdx;
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
 
             var position = GetPositionAbsoluteTopLeft();
             float height = RowHeight * (VisibleRowsCount + 1); // One row is taken up by the header of the table.
             m_styleDef.Texture.Draw(position, Size,
-                ApplyColorMaskModifiers(ColorMask, Enabled, transitionAlpha));
+                ApplyColorMaskModifiers(ColorMask, Enabled, backgroundTransitionAlpha));
 
             if (HeaderVisible)
                 DrawHeader(transitionAlpha);

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlTextbox.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlTextbox.cs
@@ -260,14 +260,14 @@ namespace Sandbox.Graphics.GUI
 
         #endregion
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
             if (!Visible)
                 return;
 
-            m_compositeBackground.Draw(GetPositionAbsoluteTopLeft(), Size, ApplyColorMaskModifiers(ColorMask, Enabled, transitionAlpha));
+            m_compositeBackground.Draw(GetPositionAbsoluteTopLeft(), Size, ApplyColorMaskModifiers(ColorMask, Enabled, backgroundTransitionAlpha));
 
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
 
             var textAreaRelative = m_textAreaRelative;
             var textArea = textAreaRelative;

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlTreeView.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlTreeView.cs
@@ -52,7 +52,7 @@ namespace Sandbox.Graphics.GUI
             m_treeView.ClearItems();
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
             if (Visible)
             {
@@ -66,7 +66,7 @@ namespace Sandbox.Graphics.GUI
                 ShowToolTip(null);
             }
 
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
         }
 
         public override MyGuiControlBase HandleInput()

--- a/Sources/Sandbox.Graphics/Gui/MyGuiScreenBase.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiScreenBase.cs
@@ -161,8 +161,8 @@ namespace Sandbox.Graphics.GUI
             Vector2? size = null,
             bool isTopMostScreen = false,
             string backgroundTexture = null, 
-            float backgroundTransition = 1.0f,
-            float guiTransition = 1.0f)
+            float backgroundTransition = 0.0f,
+            float guiTransition = 0.0f)
         {
             m_controls = new MyGuiControls(this);
             m_backgroundFadeColor = Color.White;
@@ -860,7 +860,6 @@ namespace Sandbox.Graphics.GUI
         //  Returns true or false to let child implementation know if it has to run its own version of draw.
         public virtual bool Draw()
         {
-            float savedtransition = m_transitionAlpha;
             //  This is just background of the screen rectangle
             if ((m_backgroundColor.HasValue) && (m_size.HasValue))
             {
@@ -874,31 +873,36 @@ namespace Sandbox.Graphics.GUI
                     }
                 }
 
-                m_transitionAlpha = m_backgroundTransition;
-                MyGuiManager.DrawSpriteBatch(m_backgroundTexture, m_position, m_size.Value, ApplyTransitionAlpha(m_backgroundColor.Value), MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER);
+                MyGuiManager.DrawSpriteBatch(m_backgroundTexture, m_position, m_size.Value, ApplyTransitionAlpha(m_backgroundColor.Value, m_guiTransition != 0 ? m_backgroundTransition : m_transitionAlpha), MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER);
 
                 //if (MyFakes.DRAW_GUI_SCREEN_BORDERS && MyFinalBuildConstants.IS_DEBUG)
                 //{
                 //    MyGuiManager2.DrawBorders(GetPositionAbsoluteTopLeft(), m_size.Value, Color.White, 1);
                 //}
             }
-            m_transitionAlpha = m_guiTransition;
-            DrawElements(m_transitionAlpha);
-            DrawControls(m_transitionAlpha);
-            m_transitionAlpha = savedtransition;
+            if (m_guiTransition != 0)
+            {
+                DrawElements(m_guiTransition, m_backgroundTransition);
+                DrawControls(m_guiTransition, m_backgroundTransition);
+            }
+            else
+            {
+                DrawElements(m_transitionAlpha, m_transitionAlpha);
+                DrawControls(m_transitionAlpha, m_transitionAlpha);
+            }
             return true;
         }
 
-        private void DrawElements(float transitionAlpha)
+        private void DrawElements(float transitionAlpha, float backgroundTransitionAlpha)
         {
             foreach (var element in Elements)
             {
                 if (element.Visible)
-                    element.Draw(transitionAlpha);
+                    element.Draw(transitionAlpha, backgroundTransitionAlpha);
             }
         }
 
-        private void DrawControls(float transitionAlpha)
+        private void DrawControls(float transitionAlpha, float backgroundTransitionAlpha)
         {
             //  Then draw all screen controls, except opened combobox and drag and drop - must be drawn as last
             // foreach (MyGuiControlBase control in Controls.GetVisibleControls())  //dont use this - allocations
@@ -909,7 +913,7 @@ namespace Sandbox.Graphics.GUI
                 if (control != m_comboboxHandlingNow && control != m_listboxDragAndDropHandlingNow)
                 {
                     //if (MySandboxGame.IsPaused && !control.DrawWhilePaused) continue;
-                    control.Draw(transitionAlpha);
+                    control.Draw(transitionAlpha, backgroundTransitionAlpha);
                 }
             }
 
@@ -917,12 +921,12 @@ namespace Sandbox.Graphics.GUI
 
             if (m_comboboxHandlingNow != null)
             {
-                m_comboboxHandlingNow.Draw(transitionAlpha);
+                m_comboboxHandlingNow.Draw(transitionAlpha, backgroundTransitionAlpha);
             }
 
             if (m_listboxDragAndDropHandlingNow != null)
             {
-                m_listboxDragAndDropHandlingNow.Draw(transitionAlpha);
+                m_listboxDragAndDropHandlingNow.Draw(transitionAlpha, backgroundTransitionAlpha);
             }
 
             // draw tooltips only when screen has focus
@@ -1071,10 +1075,10 @@ namespace Sandbox.Graphics.GUI
         }
 
         //  Changes color according to transition alpha, this when opening the screen - it from 100% transparent to 100% opaque. When closing it's opposite.
-        protected Color ApplyTransitionAlpha(Vector4 color)
+        protected Color ApplyTransitionAlpha(Vector4 color, float transition)
         {
             Vector4 ret = color;
-            ret.W *= m_transitionAlpha;
+            ret.W *= transition;
             return new Color(ret);
         }
 

--- a/Sources/Sandbox.Graphics/Gui/MyGuiScreenBase.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiScreenBase.cs
@@ -73,6 +73,8 @@ namespace Sandbox.Graphics.GUI
 
         //Fields
         protected float m_transitionAlpha;
+        protected float m_backgroundTransition;
+        protected float m_guiTransition;
         private MyGuiControls m_controls;
         protected Vector2 m_position;
         protected Color m_backgroundFadeColor;
@@ -158,7 +160,9 @@ namespace Sandbox.Graphics.GUI
             Vector4? backgroundColor = null,
             Vector2? size = null,
             bool isTopMostScreen = false,
-            string backgroundTexture = null)
+            string backgroundTexture = null, 
+            float backgroundTransition = 1.0f,
+            float guiTransition = 1.0f)
         {
             m_controls = new MyGuiControls(this);
             m_backgroundFadeColor = Color.White;
@@ -174,6 +178,8 @@ namespace Sandbox.Graphics.GUI
             m_backgroundTexture = backgroundTexture;
 
             Elements = new MyGuiControls(this);
+            m_backgroundTransition = backgroundTransition;
+            m_guiTransition = guiTransition;
             CreateCloseButton();
             SetDefaultCloseButtonOffset();
         }
@@ -854,6 +860,7 @@ namespace Sandbox.Graphics.GUI
         //  Returns true or false to let child implementation know if it has to run its own version of draw.
         public virtual bool Draw()
         {
+            float savedtransition = m_transitionAlpha;
             //  This is just background of the screen rectangle
             if ((m_backgroundColor.HasValue) && (m_size.HasValue))
             {
@@ -867,6 +874,7 @@ namespace Sandbox.Graphics.GUI
                     }
                 }
 
+                m_transitionAlpha = m_backgroundTransition;
                 MyGuiManager.DrawSpriteBatch(m_backgroundTexture, m_position, m_size.Value, ApplyTransitionAlpha(m_backgroundColor.Value), MyGuiDrawAlignEnum.HORISONTAL_CENTER_AND_VERTICAL_CENTER);
 
                 //if (MyFakes.DRAW_GUI_SCREEN_BORDERS && MyFinalBuildConstants.IS_DEBUG)
@@ -874,9 +882,10 @@ namespace Sandbox.Graphics.GUI
                 //    MyGuiManager2.DrawBorders(GetPositionAbsoluteTopLeft(), m_size.Value, Color.White, 1);
                 //}
             }
-
+            m_transitionAlpha = m_guiTransition;
             DrawElements(m_transitionAlpha);
             DrawControls(m_transitionAlpha);
+            m_transitionAlpha = savedtransition;
             return true;
         }
 

--- a/Sources/Sandbox.Graphics/Gui/TreeView/MyTreeViewItemDragAndDrop.cs
+++ b/Sources/Sandbox.Graphics/Gui/TreeView/MyTreeViewItemDragAndDrop.cs
@@ -56,9 +56,9 @@ namespace Sandbox.Graphics.GUI
             return captured;
         }
 
-        public override void Draw(float transitionAlpha)
+        public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
-            base.Draw(transitionAlpha);
+            base.Draw(transitionAlpha, backgroundTransitionAlpha);
             if (Dragging)
             {
                 Debug.Assert(DraggedItem != null);

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
@@ -2598,6 +2598,18 @@ World size: {1}</value>
   <data name="ToolTipGameOptionsShowPlayerNames" xml:space="preserve">
     <value>Show player names above their characters. This feature must also be enabled in world settings.</value>
   </data>
+  <data name="ScreenOptionsGame_UITransparency" xml:space="preserve">
+    <value>UI transparency</value>
+  </data>
+  <data name="ToolTipGameOptionsUITransparency" xml:space="preserve">
+    <value>Change transparency of UI dialogs.</value>
+  </data>
+  <data name="ScreenOptionsGame_UIBkTransparency" xml:space="preserve">
+    <value>UI background transparency</value>
+  </data>
+  <data name="ToolTipGameOptionsUIBkTransparency" xml:space="preserve">
+    <value>Change transparency of UI dialogs background.</value>
+  </data>
   <data name="ToolTipTerminalInventory_ThrowOut" xml:space="preserve">
     <value>Drop item</value>
   </data>


### PR DESCRIPTION
transparency setting for ingame GUI.
transparency settings affects only terminal screen, toolbar config screen, and game settings screen (this one, to show preview what it will look like)
terminal foreground transparency can be set from 10 to 100%
terminal background transparency can be set from 0 to 100%
http://imgur.com/a/i8vpz