### PR TITLE
API: IMyOxygenBottle

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/IMyOxygenBottle.cs
+++ b/Sources/Sandbox.Common/ModAPI/IMyOxygenBottle.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sandbox.ModAPI
+{
+    /// <summary>
+    /// Interface for accessing oxygen bottle properties
+    /// </summary>
+    public interface IMyOxygenBottle : Ingame.IMyOxygenBottle
+    {
+        /* SET is not safe atm. not implementing
+        /// <summary>
+        /// Current oxygen level
+        /// </summary>
+        float OxygenLevel { get; set; }
+        */
+    }
+}

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyOxygenBottle.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyOxygenBottle.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sandbox.ModAPI.Ingame
+{
+    /// <summary>
+    /// Interface for accessing oxygen bottle properties
+    /// </summary>
+    public interface IMyOxygenBottle : Interfaces.IMyInventoryItem
+    {
+        /// <summary>
+        /// Current oxygen level
+        /// </summary>
+        float OxygenLevel { get; }
+        /// <summary>
+        /// Bottle capacity (in O2 units)
+        /// </summary>
+        float Capacity { get; }
+    }
+}

--- a/Sources/Sandbox.Common/Sandbox.Common.csproj
+++ b/Sources/Sandbox.Common/Sandbox.Common.csproj
@@ -150,6 +150,7 @@
     <Compile Include="ModAPI\IMyInventory.cs" />
     <Compile Include="ModAPI\IMyLandingGear.cs" />
     <Compile Include="ModAPI\IMyMotorStator.cs" />
+    <Compile Include="ModAPI\IMyOxygenBottle.cs" />
     <Compile Include="ModAPI\IMyOxygenGenerator.cs" />
     <Compile Include="ModAPI\IMyParallelTask.cs" />
     <Compile Include="ModAPI\IMyPistonBase.cs" />
@@ -174,6 +175,7 @@
     <Compile Include="ModAPI\IMyVoxelShapeRamp.cs" />
     <Compile Include="ModAPI\IMyVoxelShapeSphere.cs" />
     <Compile Include="ModAPI\Ingame\IMyAirVent.cs" />
+    <Compile Include="ModAPI\Ingame\IMyOxygenBottle.cs" />
     <Compile Include="ModAPI\Ingame\IMyPowerProducer.cs" />
     <Compile Include="ModAPI\Ingame\IMyRadioAntenna.cs" />
     <Compile Include="ModAPI\Ingame\IMyAssembler.cs" />

--- a/Sources/Sandbox.Game/ModAPI/MyOxygenBottle_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/MyOxygenBottle_ModAPI.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Sandbox.ModAPI;
+using Sandbox.ModAPI.Ingame;
+using Sandbox.Common.ObjectBuilders.Definitions;
+using Sandbox.Definitions;
+
+namespace Sandbox.Game
+{
+    public partial struct MyPhysicalInventoryItem : Sandbox.ModAPI.IMyOxygenBottle
+    {
+        float ModAPI.Ingame.IMyOxygenBottle.Capacity
+        {
+            get
+            {
+                var content = Content as MyObjectBuilder_OxygenContainerObject;
+                if (content != null)
+                {
+                    var physicalItem = MyDefinitionManager.Static.GetPhysicalItemDefinition(Content) as MyOxygenContainerDefinition;
+                    return physicalItem != null ? physicalItem.Capacity : 0;
+                }
+                return 0;
+            }
+        }
+
+        float ModAPI.Ingame.IMyOxygenBottle.OxygenLevel
+        {
+            get
+            {
+                var content = Content as MyObjectBuilder_OxygenContainerObject;
+                if (content != null)
+                {
+                    return content.OxygenLevel;
+                }
+                return 0;
+            }
+        }
+
+        /* set is not safe atm due sync ... not implementing
+        float ModAPI.IMyOxygenBottle.OxygenLevel
+        {
+            get
+            {
+                var content = Content as MyObjectBuilder_OxygenContainerObject;
+                if (content != null)
+                {
+                    return content.OxygenLevel;
+                }
+                return 0;
+            }
+
+            set
+            {
+                var content = Content as MyObjectBuilder_OxygenContainerObject;
+                if (content != null && value != content.OxygenLevel)
+                {
+                    content.OxygenLevel = value;                    
+                }
+            }
+        }
+        */
+    }
+}

--- a/Sources/Sandbox.Game/Sandbox.Game.csproj
+++ b/Sources/Sandbox.Game/Sandbox.Game.csproj
@@ -770,6 +770,7 @@
     <Compile Include="ModAPI\MyGridTerminalSystem_ModAPI.cs" />
     <Compile Include="ModAPI\MyLargeTurretBase_ModAPI.cs" />
     <Compile Include="ModAPI\MyLaserAntenna_ModAPI.cs" />
+    <Compile Include="ModAPI\MyOxygenBottle_ModAPI.cs" />
     <Compile Include="ModAPI\MyVoxelShapes_ModAPI.cs" />
     <Compile Include="Game\Components\Renders\MyRenderComponentEnvironmentItems.cs" />
     <Compile Include="MySplashScreen.cs">


### PR DESCRIPTION
Interface to retrieve OxygenLevel and Capacity of oxygen container in inventory

```
 IMyInventoryOwner owner = (IMyInventoryOwner) blocks[0];
    IMyInventory inventory = (IMyInventory)owner.GetInventory(0);
    var items = inventory.GetItems();
    for(int i=0;i<items.Count;i++)
    {
        if (items[i].Content.TypeId == typeof(Sandbox.Common.ObjectBuilders.Definitions.MyObjectBuilder_OxygenContainerObject))
        {
            var bottle = items[i] as IMyOxygenBottle; 
            Echo ("Bottle found, fill level " + String.Format("{0:P2}", bottle.OxygenLevel) + ", capacity " + bottle.Capacity + " units");
        }
    }
```

capacity is important, because of modified bottles, level might not be enough to estimate, how much oxygen you have left (play time wise)

i've decided to not add "set" function for modapi for direct oxygen level modification trough mod script, because currently there is no simple way to invoke value synchronization ... this might change in future.
