### PR TITLE
Added option to invert joystick x and y axis

### DIFF
--- a/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
+++ b/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
@@ -225,6 +225,16 @@ namespace Sandbox.Game.Localization
         public static readonly MyStringId JoystickButtonDown = MyStringId.GetOrCompute("JoystickButtonDown");
 
         ///<summary>
+        ///Invert Joystick X axis
+        ///</summary>
+        public static readonly MyStringId InvertJoystickX = MyStringId.GetOrCompute("InvertJoystickX");
+
+        ///<summary>
+        ///Invert Joystick Y axis
+        ///</summary>
+        public static readonly MyStringId InvertJoystickY = MyStringId.GetOrCompute("InvertJoystickY");
+
+        ///<summary>
         ///Joystick deadzone width
         ///</summary>
         public static readonly MyStringId JoystickDeadzone = MyStringId.GetOrCompute("JoystickDeadzone");

--- a/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
+++ b/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
@@ -225,12 +225,12 @@ namespace Sandbox.Game.Localization
         public static readonly MyStringId JoystickButtonDown = MyStringId.GetOrCompute("JoystickButtonDown");
 
         ///<summary>
-        ///Invert Joystick X axis
+        ///Invert joystick X axis
         ///</summary>
         public static readonly MyStringId InvertJoystickX = MyStringId.GetOrCompute("InvertJoystickX");
 
         ///<summary>
-        ///Invert Joystick Y axis
+        ///Invert joystick Y axis
         ///</summary>
         public static readonly MyStringId InvertJoystickY = MyStringId.GetOrCompute("InvertJoystickY");
 

--- a/Sources/Sandbox.Game/Game/Screens/MyGuiScreenOptionsControls.cs
+++ b/Sources/Sandbox.Game/Game/Screens/MyGuiScreenOptionsControls.cs
@@ -51,6 +51,8 @@ namespace Sandbox.Game.Gui
         MyGuiControlSlider m_joystickDeadzoneSlider;
         MyGuiControlSlider m_joystickExponentSlider;
         MyGuiControlCombobox m_joystickCombobox;
+        MyGuiControlCheckbox m_invertJoystickXCheckbox;
+        MyGuiControlCheckbox m_invertJoystickYCheckbox;
 
         Vector2 m_controlsOriginLeft;
         Vector2 m_controlsOriginRight;
@@ -324,11 +326,15 @@ namespace Sandbox.Game.Gui
             if (MyFakes.ENABLE_JOYSTICK_SETTINGS)
             {
                 const float multiplierJoystick = 6.5f;
-                const float multiplierSensitivity = 8;
-                const float multiplierExponent = 9;
-                const float multiplierDeadzone = 10;
+                const float multiplierJoystickInvertX = 8;
+                const float multiplierJoystickInvertY = 9;
+                const float multiplierSensitivity = 10;
+                const float multiplierExponent = 11;
+                const float multiplierDeadzone = 12;
 
                 m_allControls[MyGuiControlTypeEnum.General].Add(MakeLabel(multiplierJoystick, MySpaceTexts.Joystick));
+                m_allControls[MyGuiControlTypeEnum.General].Add(MakeLabel(multiplierJoystickInvertX, MySpaceTexts.InvertJoystickX));
+                m_allControls[MyGuiControlTypeEnum.General].Add(MakeLabel(multiplierJoystickInvertY, MySpaceTexts.InvertJoystickY));
                 m_allControls[MyGuiControlTypeEnum.General].Add(MakeLabel(multiplierSensitivity, MySpaceTexts.JoystickSensitivity));
                 m_allControls[MyGuiControlTypeEnum.General].Add(MakeLabel(multiplierExponent, MySpaceTexts.JoystickExponent));
                 m_allControls[MyGuiControlTypeEnum.General].Add(MakeLabel(multiplierDeadzone, MySpaceTexts.JoystickDeadzone));
@@ -337,6 +343,18 @@ namespace Sandbox.Game.Gui
                 m_joystickCombobox.ItemSelected += OnSelectJoystick;
                 AddJoysticksToComboBox();
                 m_allControls[MyGuiControlTypeEnum.General].Add(m_joystickCombobox);
+
+                m_invertJoystickXCheckbox = new MyGuiControlCheckbox(
+                     position: m_controlsOriginRight + multiplierJoystickInvertX * MyGuiConstants.CONTROLS_DELTA,
+                     isChecked: MyInput.Static.GetJoystickXInversion(),
+                     originAlign: MyGuiDrawAlignEnum.HORISONTAL_LEFT_AND_VERTICAL_CENTER);
+                m_allControls[MyGuiControlTypeEnum.General].Add(m_invertJoystickXCheckbox);
+
+                m_invertJoystickYCheckbox = new MyGuiControlCheckbox(
+                     position: m_controlsOriginRight + multiplierJoystickInvertY * MyGuiConstants.CONTROLS_DELTA,
+                     isChecked: MyInput.Static.GetJoystickYInversion(),
+                     originAlign: MyGuiDrawAlignEnum.HORISONTAL_LEFT_AND_VERTICAL_CENTER);
+                m_allControls[MyGuiControlTypeEnum.General].Add(m_invertJoystickYCheckbox);
 
                 m_joystickSensitivitySlider = new MyGuiControlSlider(
                     position: m_controlsOriginRight + multiplierSensitivity * MyGuiConstants.CONTROLS_DELTA + new Vector2(MyGuiConstants.COMBOBOX_MEDIUM_SIZE.X / 2.0f, 0),
@@ -493,6 +511,8 @@ namespace Sandbox.Game.Gui
             if (MyFakes.ENABLE_JOYSTICK_SETTINGS)
             {
                 MyInput.Static.JoystickInstanceName = m_joystickCombobox.GetSelectedIndex() == 0 ? null : m_joystickCombobox.GetSelectedValue().ToString();
+                MyInput.Static.SetJoystickXInversion(m_invertJoystickXCheckbox.IsChecked);
+                MyInput.Static.SetJoystickYInversion(m_invertJoystickYCheckbox.IsChecked);
                 MyInput.Static.SetJoystickSensitivity(m_joystickSensitivitySlider.Value);
                 MyInput.Static.SetJoystickExponent(m_joystickExponentSlider.Value);
                 MyInput.Static.SetJoystickDeadzone(m_joystickDeadzoneSlider.Value);

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
@@ -249,10 +249,10 @@ Remove the original control?</value>
     <value>JDDown</value>
   </data>
 	<data name="InvertJoystickX" xml:space="preserve">
-    <value>Invert Joystick X axis</value>
+    <value>Invert joystick X axis</value>
   </data>
 	<data name="InvertJoystickY" xml:space="preserve">
-    <value>Invert Joystick Y axis</value>
+    <value>Invert joystick Y axis</value>
   </data>
   <data name="JoystickDeadzone" xml:space="preserve">
     <value>Joystick deadzone width</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
@@ -248,6 +248,12 @@ Remove the original control?</value>
   <data name="JoystickButtonDown" xml:space="preserve">
     <value>JDDown</value>
   </data>
+	<data name="InvertJoystickX" xml:space="preserve">
+    <value>Invert Joystick X axis</value>
+  </data>
+	<data name="InvertJoystickY" xml:space="preserve">
+    <value>Invert Joystick Y axis</value>
+  </data>
   <data name="JoystickDeadzone" xml:space="preserve">
     <value>Joystick deadzone width</value>
   </data>

--- a/Sources/VRage.Input/MyDirectXInput.cs
+++ b/Sources/VRage.Input/MyDirectXInput.cs
@@ -87,6 +87,8 @@ namespace VRage.Input
                 }
             }
         }
+        bool m_joystickXIsInverted;
+        bool m_joystickYIsInverted;
         float m_joystickSensitivity;
         float m_joystickDeadzone;
         float m_joystickExponent;
@@ -94,6 +96,8 @@ namespace VRage.Input
         public bool IsMouseYInvertedDefault { get { return false; } }
         public float MouseSensitivityDefault { get { return 1.655f; } }
         public string JoystickInstanceNameDefault { get { return null; } }
+        public bool IsJoystickXInvertedDefault { get { return false; } }
+        public bool IsJoystickYInvertedDefault { get { return false; } }
         public float JoystickSensitivityDefault { get { return 2.0f; } }
         public float JoystickExponentDefault { get { return 2.0f; } }
         public float JoystickDeadzoneDefault { get { return 0.2f; } }
@@ -153,6 +157,8 @@ namespace VRage.Input
             m_mouseYIsInverted = IsMouseYInvertedDefault;
             m_mouseSensitivity = MouseSensitivityDefault;
             m_joystickInstanceName = JoystickInstanceNameDefault;
+            m_joystickXIsInverted = IsJoystickXInvertedDefault;
+            m_joystickYIsInverted = IsJoystickYInvertedDefault;
             m_joystickSensitivity = JoystickSensitivityDefault;
             m_joystickDeadzone = JoystickDeadzoneDefault;
             m_joystickExponent = JoystickExponentDefault;
@@ -1419,6 +1425,34 @@ namespace VRage.Input
             return GetJoystickAxisStateRaw(MyJoystickAxesEnum.Ypos);
         }
 
+        public MyJoystickAxesEnum GetInvertedJoystickModifiedAxis(MyJoystickAxesEnum axis)
+        {
+            if (m_joystickXIsInverted) // switch X axis if inverted
+            {
+                switch (axis)
+                {
+                    case MyJoystickAxesEnum.RotationXneg:
+                        axis = MyJoystickAxesEnum.RotationXpos;
+                        break;
+                    case MyJoystickAxesEnum.RotationXpos:
+                        axis = MyJoystickAxesEnum.RotationXneg;
+                        break;
+                }
+            }
+            if (m_joystickYIsInverted) // switch Y axis if inverted
+            {
+                switch (axis)
+                {
+                    case MyJoystickAxesEnum.RotationYneg:
+                        axis = MyJoystickAxesEnum.RotationYpos;
+                        break;
+                    case MyJoystickAxesEnum.RotationYpos:
+                        axis = MyJoystickAxesEnum.RotationYneg;
+                        break;
+                }
+            }
+            return axis;
+        }
 
         //  Find out how much a specific joystick half-axis is pressed.
         //  Return a number between 0 and 1 (taking deadzone, sensitivity and non-linearity into account).
@@ -1426,6 +1460,7 @@ namespace VRage.Input
         {
             if (m_joystickConnected && IsJoystickAxisSupported(axis))
             {
+                axis = GetInvertedJoystickModifiedAxis(axis);
                 // Input position scaled to (-1..1).
                 float position = ((float)GetJoystickAxisStateRaw(axis) - (float)MyJoystickConstants.CENTER_AXIS) / (float)MyJoystickConstants.CENTER_AXIS;
 
@@ -1473,6 +1508,7 @@ namespace VRage.Input
         {
             if (m_joystickConnected && IsJoystickAxisSupported(axis))
             {
+                axis = GetInvertedJoystickModifiedAxis(axis);
                 // Input position scaled to (-1..1).
                 float position = ((float)GetPreviousJoystickAxisStateRaw(axis) - (float)MyJoystickConstants.CENTER_AXIS) / (float)MyJoystickConstants.CENTER_AXIS;
 
@@ -1770,6 +1806,26 @@ namespace VRage.Input
         {
             get;
             set;
+        }
+
+        public bool GetJoystickXInversion()
+        {
+            return m_joystickXIsInverted;
+        }
+
+        public bool GetJoystickYInversion()
+        {
+            return m_joystickYIsInverted;
+        }
+
+        public void SetJoystickXInversion(bool inverted)
+        {
+            m_joystickXIsInverted = inverted;
+        }
+
+        public void SetJoystickYInversion(bool inverted)
+        {
+            m_joystickYIsInverted = inverted;
         }
 
         public event Action<bool> JoystickConnected;
@@ -2165,6 +2221,8 @@ namespace VRage.Input
             m_mouseSensitivity = MouseSensitivityDefault;
 
             m_joystickSensitivity = JoystickSensitivityDefault;
+            m_joystickXIsInverted = IsJoystickXInvertedDefault;
+            m_joystickYIsInverted = IsJoystickYInvertedDefault;
             m_joystickDeadzone = JoystickDeadzoneDefault;
             m_joystickExponent = JoystickExponentDefault;
             CloneControls(m_defaultGameControlsList, m_gameControlsList);
@@ -2179,6 +2237,8 @@ namespace VRage.Input
             controlsGeneral.Dictionary.Add("mouseYIsInverted", m_mouseYIsInverted.ToString());
             controlsGeneral.Dictionary.Add("mouseSensitivity", m_mouseSensitivity.ToString(System.Globalization.CultureInfo.InvariantCulture));
             controlsGeneral.Dictionary.Add("joystickInstanceName", m_joystickInstanceName);
+            controlsGeneral.Dictionary.Add("joystickXIsInverted", m_joystickXIsInverted.ToString());
+            controlsGeneral.Dictionary.Add("joystickYIsInverted", m_joystickYIsInverted.ToString());
             controlsGeneral.Dictionary.Add("joystickSensitivity", m_joystickSensitivity.ToString(System.Globalization.CultureInfo.InvariantCulture));
             controlsGeneral.Dictionary.Add("joystickExponent", m_joystickExponent.ToString(System.Globalization.CultureInfo.InvariantCulture));
             controlsGeneral.Dictionary.Add("joystickDeadzone", m_joystickDeadzone.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -2217,6 +2277,8 @@ namespace VRage.Input
                 JoystickInstanceName = (string)controlsGeneral["joystickInstanceName"];
 
                 m_joystickSensitivity = float.Parse((string)controlsGeneral["joystickSensitivity"], System.Globalization.CultureInfo.InvariantCulture);
+                m_joystickXIsInverted = bool.Parse((string)controlsGeneral["joystickXIsInverted"]);
+                m_joystickYIsInverted = bool.Parse((string)controlsGeneral["joystickYIsInverted"]);
                 m_joystickExponent = float.Parse((string)controlsGeneral["joystickExponent"], System.Globalization.CultureInfo.InvariantCulture);
                 m_joystickDeadzone = float.Parse((string)controlsGeneral["joystickDeadzone"], System.Globalization.CultureInfo.InvariantCulture);
 

--- a/Sources/VRage/Input/IMyInput.cs
+++ b/Sources/VRage/Input/IMyInput.cs
@@ -297,6 +297,14 @@ namespace VRage.Input
         // Used for finding out whether joystick has been used last time. Otherwise, it returns false. 
         bool IsJoystickLastUsed { get; }
 
+        bool GetJoystickXInversion();
+
+        bool GetJoystickYInversion();
+
+        void SetJoystickXInversion(bool inverted);
+
+        void SetJoystickYInversion(bool inverted);
+
         // event which fires when you select joystick
         event Action<bool> JoystickConnected;
 

--- a/Sources/VRage/Input/MyNullInput.cs
+++ b/Sources/VRage/Input/MyNullInput.cs
@@ -111,6 +111,10 @@ namespace VRage.Input
         bool IMyInput.IsNewGamepadKeyDownPressed() { return false; }
         bool IMyInput.IsNewGamepadKeyUpPressed() { return false; }
         void IMyInput.GetActualJoystickState(StringBuilder text) { }
+        bool IMyInput.GetJoystickXInversion() { return false; }
+        bool IMyInput.GetJoystickYInversion() { return false; }
+        void IMyInput.SetJoystickXInversion(bool inverted) { }
+        void IMyInput.SetJoystickYInversion(bool inverted) { }
 
         bool IMyInput.IsAnyMouseOrJoystickPressed() { return false; }
         bool IMyInput.IsAnyNewMouseOrJoystickPressed() { return false; }


### PR DESCRIPTION
Added and changed the necessary functions and controls in order to add the ability to invert the joystick's x and y axis without modifying the mouse.

There are 2 problems with what I have done, the first is the 'Invert X axis' occasionally didn't save properly, but this was more likely my fault in early testing (it hasn't done it for a while). The second is that the Y axis only seems to register in either direction when the X axis is out of it's deadzone. This problem still exists no matter to inversion setting, so I don't think it is a problem with my changes.

I have only been able to test with an Xbox One controller so far, and I have not been able to test to see if the labels in the controls option menu work properly due to me being forced to use the steam installed content, but it should work.