### PR TITLE
Background fade following background transparency setting

### DIFF
--- a/Sources/Sandbox.Graphics/Gui/MyGuiScreenBase.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiScreenBase.cs
@@ -143,7 +143,7 @@ namespace Sandbox.Graphics.GUI
             get
             {
                 var tmp = m_backgroundFadeColor;
-                tmp.A = (byte)(tmp.A * m_transitionAlpha);
+                tmp.A = (byte)(tmp.A * (m_backgroundTransition != 1 ? m_backgroundTransition : m_transitionAlpha));
                 return tmp;
             }
         }


### PR DESCRIPTION
GUI transparency settings affects terminal, and it's background, but there is still "background fade" layer, which is not affected. this makes backgroudn transparency pointless ... this fix reduces also "fade layer" transparency, therefore UI can become real transparent

affects terminal and "game options" only.

http://imgur.com/2xfvwqC