### PR TITLE
FIX: news "next button" not working

### DIFF
--- a/Sources/Sandbox.Game/Game/Screens/Helpers/MyGuiControlNews.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Helpers/MyGuiControlNews.cs
@@ -217,7 +217,7 @@ namespace Sandbox.Game.Screens.Helpers
             m_labelPages.Position = new Vector2(m_bottomPanel.Position.X - m_bottomPanel.Size.X + 2f*spacing,
                                                 m_buttonPrev.Position.Y);
 
-            m_textNewsEntry.Size = new Vector2(posXRight - posXLeft, (m_buttonNext.Position.Y - m_textNewsEntry.Position.Y));
+            m_textNewsEntry.Size = new Vector2(posXRight - posXLeft, (m_buttonNext.Position.Y - m_buttonNext.Size.Y - m_textNewsEntry.Position.Y));
 
             m_textError.Size = Size - 2f * padding;
             m_bottomPanel.Size = new Vector2(0.125f, m_buttonPrev.Size.Y + 0.015f);


### PR DESCRIPTION
next button is overlapping with vertical scrollbar when news is too long.
this change adds to calculation also "height" of next button, so news text area ends right above "next" button and scrollbar doesn't catch mouse click that should belong to "next" button.
