### PR TITLE
Fix for outdated modded Interior Doors

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyDoor.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyDoor.cs
@@ -242,7 +242,7 @@ namespace Sandbox.Game.Entities
 
         private void OnStateChange()
         {
-            float speed = ((MyDoorDefinition)BlockDefinition).OpeningSpeed;
+            float speed = (BlockDefinition is MyDoorDefinition) ? ((MyDoorDefinition)BlockDefinition).OpeningSpeed : 1f;
             m_currSpeed = m_open ? speed : -speed;
 
             NeedsUpdate = MyEntityUpdateEnum.EACH_FRAME | MyEntityUpdateEnum.EACH_100TH_FRAME;


### PR DESCRIPTION
#35  Added the ability to mod Interior Doors Opening Speed, sadly this
broke some older Mods that didn't use the MyObjectBuilder_DoorDefinition

Even though i think those Mods should be updated anyway this fix will
make those old Doors work again