### PR TITLE
Fix oxygen loss when room has multiple air vents

### DIFF
--- a/Sources/Sandbox.Game/Game/GameSystems/MyGridOxygenSystem.cs
+++ b/Sources/Sandbox.Game/Game/GameSystems/MyGridOxygenSystem.cs
@@ -22,6 +22,7 @@ using VRage;
 using VRage.Components;
 using VRage.Input;
 using VRage.Library.Utils;
+using VRage.Utils;
 using VRageMath;
 using VRageRender;
 
@@ -539,6 +540,8 @@ namespace Sandbox.Game.GameSystems
                 }
             }
 
+            var consumerList = new List<IMyOxygenConsumer>();
+            var producerList = new List<IMyOxygenProducer>();
             foreach (var group in groups)
             {
                 if ((group.Consumers.Count == 0 || group.Producers.Count == 0) && group.Tanks.Count == 0)
@@ -546,80 +549,98 @@ namespace Sandbox.Game.GameSystems
                     continue;
                 }
 
+                // Randomize the order that consumers and producers are processed so that usage will balance
+                // out over time. (While making sure to maintain priority ordering requirements.)
+                consumerList.Clear();
+                foreach (var prioLevel in group.Consumers)
+                {
+                    int start = consumerList.Count;
+                    consumerList.AddList(prioLevel.Value);
+
+                    //Shuffle order of items just added
+                    for (int i = start; i < consumerList.Count - 1; ++i)
+                    {
+                        int j = MyUtils.GetRandomInt(i, consumerList.Count);
+                        var tmp = consumerList[i];
+                        consumerList[i] = consumerList[j];
+                        consumerList[j] = tmp;
+                    }
+                }
+                producerList.Clear();
+                foreach (var prioLevel in group.Producers)
+                {
+                    int start = producerList.Count;
+                    producerList.AddList(prioLevel.Value);
+
+                    for (int i = start; i < producerList.Count - 1; ++i)
+                    {
+                        int j = MyUtils.GetRandomInt(i, producerList.Count);
+                        var tmp = producerList[i];
+                        producerList[i] = producerList[j];
+                        producerList[j] = tmp;
+                    }
+                }
+
                 // Step through consumers and producers one-by-one,
                 //   transferring production to consumers in turn and as-needed
                 // Note that, as a safety precaution, we take care to call each consumer/producer/tank's
                 //   consume/produce functions exactly once, since the interfaces' documention does not indicate
                 //   whether multiple or 0 calls per update is acceptable (exactly one call must necessarily be safe).
-                bool producersLeft = false;
-                var producerListIter = group.Producers.GetEnumerator();
-                List<IMyOxygenProducer>.Enumerator producerIter = new List<IMyOxygenProducer>.Enumerator();
+                var producerIter = producerList.GetEnumerator();
+                bool producersLeft = producerIter.MoveNext();
                 float prodUsed = 0;
-                if (producerListIter.MoveNext())
-                {
-                    producerIter = producerListIter.Current.Value.GetEnumerator();
-                    producersLeft = producerIter.MoveNext();
-                }
 
                 var tankIter = group.NonStockpilingTanks.GetEnumerator();
                 bool tanksLeft = tankIter.MoveNext();
                 float tankUsed = 0;
 
-                foreach (var consumerList in group.Consumers)
+                foreach (var consumer in consumerList)
                 {
-                    foreach (var consumer in consumerList.Value)
+                    float need = consumer.ConsumptionNeed(deltaTime);
+                    float have=0;
+
+                    while (producersLeft && have < need)
                     {
-                        float need = consumer.ConsumptionNeed(deltaTime);
-                        float have=0;
+                        //Get production each time because it may change as consumers are satisfied
+                        float prodCapacity = producerIter.Current.ProductionCapacity(deltaTime);
+                        Debug.Assert(prodUsed <= prodCapacity, "Used more oxygen than the producer could provide");
 
-                        while (producersLeft && have < need)
+                        float use = Math.Min(need - have, prodCapacity - prodUsed);
+                        have += use;
+                        prodUsed += use;
+
+                        if (prodUsed >= prodCapacity)
                         {
-                            //Get production each time because it may change as consumers are satisfied
-                            float prodCapacity = producerIter.Current.ProductionCapacity(deltaTime);
-                            Debug.Assert(prodUsed <= prodCapacity, "Used more oxygen than the producer could provide");
+                            //Finalize current production
+                            producerIter.Current.Produce(prodCapacity);
 
-                            float use = Math.Min(need - have, prodCapacity - prodUsed);
-                            have += use;
-                            prodUsed += use;
-
-                            if (prodUsed >= prodCapacity)
-                            {
-                                //Finalize current production
-                                producerIter.Current.Produce(prodCapacity);
-
-                                //Have exhausted current producer, move to next
-                                producersLeft = producerIter.MoveNext();
-                                if (!producersLeft && producerListIter.MoveNext())
-                                {
-                                    producerIter = producerListIter.Current.Value.GetEnumerator();
-                                    producersLeft = producerIter.MoveNext();
-                                }
-                                prodUsed = 0.0f;
-                            }
+                            //Have exhausted current producer, move to next
+                            producersLeft = producerIter.MoveNext();
+                            prodUsed = 0.0f;
                         }
-                        while (tanksLeft && have < need)
-                        {
-                            //Note we don't bother balancing usage here, since tank levels are re-balanced later
-                            //  anyways
-                            float tankAmount = tankIter.Current.Capacity * tankIter.Current.FilledRatio;
-
-                            float use = Math.Min(need - have, tankAmount - tankUsed);
-                            have += use;
-                            tankUsed += use;
-
-                            if (tankUsed >= tankAmount)
-                            {
-                                //Finalize current tank usage
-                                tankIter.Current.Drain(tankAmount);
-
-                                //Have exhausted current tank, move to next
-                                tanksLeft = tankIter.MoveNext();
-                                tankUsed = 0.0f;
-                            }
-                        }
-
-                        consumer.Consume(have);
                     }
+                    while (tanksLeft && have < need)
+                    {
+                        //Note we don't bother balancing usage here, since tank levels are re-balanced later
+                        //  anyways
+                        float tankAmount = tankIter.Current.Capacity * tankIter.Current.FilledRatio;
+
+                        float use = Math.Min(need - have, tankAmount - tankUsed);
+                        have += use;
+                        tankUsed += use;
+
+                        if (tankUsed >= tankAmount)
+                        {
+                            //Finalize current tank usage
+                            tankIter.Current.Drain(tankAmount);
+
+                            //Have exhausted current tank, move to next
+                            tanksLeft = tankIter.MoveNext();
+                            tankUsed = 0.0f;
+                        }
+                    }
+
+                    consumer.Consume(have);
                 }
                 if(tankUsed>0)
                 {   //Finalize last tank usage (if any)
@@ -650,11 +671,6 @@ namespace Sandbox.Game.GameSystems
 
                                 //Have exhausted current producer, move to next
                                 producersLeft = producerIter.MoveNext();
-                                if (!producersLeft && producerListIter.MoveNext())
-                                {
-                                    producerIter = producerListIter.Current.Value.GetEnumerator();
-                                    producersLeft = producerIter.MoveNext();
-                                }
                                 prodUsed = 0.0f;
                             }
                         }
@@ -666,11 +682,6 @@ namespace Sandbox.Game.GameSystems
                 {   //Still more excess production, finish off
                     producerIter.Current.Produce(prodUsed);
                     producersLeft = producerIter.MoveNext();
-                    if (!producersLeft && producerListIter.MoveNext())
-                    {
-                        producerIter = producerListIter.Current.Value.GetEnumerator();
-                        producersLeft = producerIter.MoveNext();
-                    }
                     prodUsed = 0.0f;
                 }
 


### PR DESCRIPTION
Problem: Significant oxygen loss can occur when multiple air vents are used to pressurize or depressurize a room.
http://forum.keenswh.com/threads/01-077-oxygen-loss-when-depressurize-a-room.7357431/

Cause: The current oxygen production/consumption algorithm queries air vents (all consumers/producers) without regard to which room they are attached to. Additionally, each air vent reports how much air it can use without regard to other vents attached to the same room. Finally, the possibility that an air vents requested oxygen amount could change as other vents are satisfied is neglected.

This leads to a problem when a room is near full (i.e. needs less than the air vents could supply in an update). If a room has X air vents and needs Y oxygen to be full, each of the air vents will request the full Y oxygen. A total of X\*Y oxygen is extracted from producers/tanks. When the fill process begins, the first air vent supplies Y oxygen to the room filling it. The remaining (X-1) air vents try to supply Y oxygen, but it is discarded in MyAirVent.Consume() because the room is already full, wasting (X-1)\*Y oxygen.

A similar event can happen when depressurizing (leading to the creation of oxygen).

Proposed solution: I have rewritten the consumption algorithm to query and satisfy consumers sequentially so that each consumer can accurately report the oxygen it can use (e.g., the remaining air vents in the example above would request 0 oxygen instead of Y).

One downside to this approach is that oxygen usage is no longer evenly balanced across all consumers for a given priority level (e.g., two equally sized, equally vented rooms can fill at different rates). I have attempted to mitigate this by randomizing the processing order within each priority level. The effect should be that usage will average out over time.

Testing performed: I have tested in a special creative world with 3 different room sizes from a single block to 7^3 blocks and with 1-10 air vents (where possible).  With the patch in place, oxygen can be cycled between the room and an oxygen tank without noticeable loss/creation (to 6 significant digits). In 1.088.012, the same setups show variation up and down of the oxygen volume, with only the first significant digit remaining constant. Various basic operations were tested on a single room (various combinations of filling/emptying rooms/tanks/generators).