### PR TITLE
Thruster Flame Color changeable in Terminal

### DIFF
--- a/Sources/Sandbox.Game/Game/Multiplayer/MySyncThruster.cs
+++ b/Sources/Sandbox.Game/Game/Multiplayer/MySyncThruster.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
+using VRageMath;
+
 namespace Sandbox.Game.Multiplayer
 {
     [PreloadRequired]
@@ -23,15 +25,63 @@ namespace Sandbox.Game.Multiplayer
             public float ThrustOverride;
         }
 
+        [MessageId(7317, P2PMessageEnum.Reliable)]
+        protected struct ChangeFlameColorMsg : IEntityMessage
+        {
+            public long EntityId;
+
+            public long GetEntityId() { return EntityId; }
+
+            public Color Color;
+            public override string ToString()
+            {
+                return String.Format("{0}, {1}", this.GetType().Name, this.GetEntityText());
+            }
+        }
+
         static MySyncThruster()
         {
             MySyncLayer.RegisterMessage<ChangeThrustOverrideMsg>(ChangeThrustOverrideSuccess, MyMessagePermissions.Any, MyTransportMessageEnum.Success);
+
+            MySyncLayer.RegisterMessage<ChangeFlameColorMsg>(ChangeFlameColorRequest, MyMessagePermissions.ToServer, MyTransportMessageEnum.Request);
+            MySyncLayer.RegisterMessage<ChangeFlameColorMsg>(ChangeFlameColorSuccess, MyMessagePermissions.FromServer, MyTransportMessageEnum.Success);
         }
 
         public MySyncThruster(MyThrust block)
         {
             m_block = block;
         }
+
+
+        public void SendChangeFlameColorRequest(Color color)
+        {
+            var msg = new ChangeFlameColorMsg();
+
+            msg.EntityId = m_block.EntityId;
+            msg.Color = color;
+
+            Sync.Layer.SendMessageToServer(ref msg, MyTransportMessageEnum.Request);
+        }
+        static void ChangeFlameColorRequest(ref ChangeFlameColorMsg msg, MyNetworkClient sender)
+        {
+            MyEntity entity;
+            MyEntities.TryGetEntityById(msg.EntityId, out entity);
+            if (entity is MyThrust)
+            {
+                Sync.Layer.SendMessageToAllAndSelf(ref msg, MyTransportMessageEnum.Success);
+            }
+        }
+        static void ChangeFlameColorSuccess(ref ChangeFlameColorMsg msg, MyNetworkClient sender)
+        {
+            MyEntity entity;
+            MyEntities.TryGetEntityById(msg.EntityId, out entity);
+            var thrust = entity as MyThrust;
+            if (thrust != null)
+            {
+                thrust.ThrustColor = msg.Color;
+            }
+        }
+
 
         public void SendChangeThrustOverrideRequest(float thrustOverride)
         {

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlColor.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlColor.cs
@@ -133,7 +133,7 @@ namespace Sandbox.Graphics.GUI
         public override void Draw(float transitionAlpha, float backgroundTransitionAlpha)
         {
             var position = GetPositionAbsoluteTopRight();
-            var size = new Vector2(m_BSlider.Size.X, m_textLabel.Size.Y);
+            var size = m_textLabel.GetTextSize();
             MyGuiManager.DrawSpriteBatch(
                 MyGuiConstants.BLANK_TEXTURE,
                 position,

--- a/Sources/VRage.Game/ObjectBuilders/MyObjectBuilder_Thrust.cs
+++ b/Sources/VRage.Game/ObjectBuilders/MyObjectBuilder_Thrust.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel;
 using ProtoBuf;
 using VRage.ObjectBuilders;
-
+using VRageMath;
 
 namespace Sandbox.Common.ObjectBuilders
 {
@@ -11,5 +11,17 @@ namespace Sandbox.Common.ObjectBuilders
     {
         [ProtoMember, DefaultValue(0.0f)]
         public float ThrustOverride = 0.0f;
+
+        [ProtoMember, DefaultValue(0.0f)]
+        public float FlameColorA = 0.0f;
+
+        [ProtoMember, DefaultValue(0.0f)]
+        public float FlameColorR = 0.0f;
+
+        [ProtoMember, DefaultValue(0.0f)]
+        public float FlameColorG = 0.0f;
+
+        [ProtoMember, DefaultValue(0.0f)]
+        public float FlameColorB = 0.0f;
     }
 }


### PR DESCRIPTION
This is a often requested feature which allows to change the Thruster Flame Color in the Terminal (K-Menu)

Less cluttered G-Menu
Less Blocks to load (no more x copies of the same Thruster just to have a different Flame Color)
Less work for Modders