### PR TITLE
 Fix oxygen loss when room has multiple air vents (alternate solution)

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyAirVent.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyAirVent.cs
@@ -486,6 +486,11 @@ namespace Sandbox.Game.Entities.Blocks
             }
         }
 
+        IMyOxygenSharedSpace IMyOxygenConsumer.GetSharedSpace()
+        {
+            return GetOxygenBlock().Room;
+        }
+
         int IMyOxygenProducer.GetPriority()
         {
             return 0;
@@ -556,6 +561,10 @@ namespace Sandbox.Game.Entities.Blocks
                 Debug.Assert(MyOxygenProviderSystem.GetOxygenInPoint(WorldMatrix.Translation) > 0f);
                 m_producedSinceLastUpdate = true;
             }
+        }
+        IMyOxygenSharedSpace IMyOxygenProducer.GetSharedSpace()
+        {
+            return GetOxygenBlock().Room;
         }
         #endregion
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyCockpit.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyCockpit.cs
@@ -1312,5 +1312,10 @@ namespace Sandbox.Game.Entities
                 m_oxygenLevel = 1f;
             }
         }
+
+        IMyOxygenSharedSpace IMyOxygenConsumer.GetSharedSpace()
+        {
+            return null;
+        }
     }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenFarm.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenFarm.cs
@@ -204,6 +204,11 @@ namespace Sandbox.Game.Entities.Blocks
             return 1;
         }
 
+        IMyOxygenSharedSpace IMyOxygenProducer.GetSharedSpace()
+        {
+            return null;
+        }
+
         bool IMyOxygenBlock.IsWorking()
         {
             return MySession.Static.Settings.EnableOxygen && PowerReceiver.IsPowered && IsWorking && IsFunctional;

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenGenerator.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyOxygenGenerator.cs
@@ -607,6 +607,11 @@ namespace Sandbox.Game.Entities.Blocks
                 }
             }
         }
+
+        IMyOxygenSharedSpace IMyOxygenProducer.GetSharedSpace()
+        {
+            return null;
+        }
         #endregion
 
         private float m_productionCapacityMultiplier = 1f;

--- a/Sources/Sandbox.Game/Game/GameSystems/IMyOxygenConsumer.cs
+++ b/Sources/Sandbox.Game/Game/GameSystems/IMyOxygenConsumer.cs
@@ -12,5 +12,14 @@ namespace Sandbox.Game.GameSystems
 
         // The lower the number, the higher the priority
         int GetPriority();
+
+        /// <summary>
+        /// Often a consumer may share a space (which it adds oxygen to) with other producers/consumers.
+        /// The common example would be multiple air vents connected to the same room. By returning an
+        /// object representing this space, the consumer allows detection and load balancing with other
+        /// consumers (who return the same object) sharing the same space.
+        /// </summary>
+        /// <returns>Space this consumer may share with other producers/consumers, or null if none</returns>
+        IMyOxygenSharedSpace GetSharedSpace();
     }
 }

--- a/Sources/Sandbox.Game/Game/GameSystems/IMyOxygenProducer.cs
+++ b/Sources/Sandbox.Game/Game/GameSystems/IMyOxygenProducer.cs
@@ -12,5 +12,15 @@ namespace Sandbox.Game.GameSystems
 
         // The lower the number, the higher the priority
         int GetPriority();
+
+        /// <summary>
+        /// Often a producer may share a space (which it pulls oxygen from) with other producers/consumers.
+        /// The common example would be multiple air vents connected to the same room. By returning an
+        /// object representing this space, the producer allows detection of other
+        /// producers (who return the same object) sharing the same space, so that the system doesn't try
+        /// to extract more oxygen than the space has.
+        /// </summary>
+        /// <returns>Space this producer may share with other producers/consumers, or null if none</returns>
+        IMyOxygenSharedSpace GetSharedSpace();
     }
 }

--- a/Sources/Sandbox.Game/Game/GameSystems/IMyOxygenSharedSpace.cs
+++ b/Sources/Sandbox.Game/Game/GameSystems/IMyOxygenSharedSpace.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sandbox.Game.GameSystems
+{
+    /// <summary>
+    /// Sometimes multiple IMyOxygenConsumers and/or IMyOxygenProducers may be linked
+    /// by a shared space (or other entity) from which they insert/extract oxygen. In such
+    /// cases, they should all return the same instance of an object implementing this interface
+    /// so that the common resource can be handled properly.
+    /// 
+    /// The quintessential example of this is air vents, which multiple can be attached
+    /// to same room.
+    /// </summary>
+    public interface IMyOxygenSharedSpace
+    {
+        /// <summary>
+        /// The maximum amount of oxygen this space can hold.
+        /// </summary>
+        double MaxCapacity
+        {
+            get;
+        }
+
+        /// <summary>
+        /// The current amount of oxygen this space is holding.
+        /// </summary>
+        double CurrentFill
+        {
+            get;
+        }
+    }
+}

--- a/Sources/Sandbox.Game/Sandbox.Game.csproj
+++ b/Sources/Sandbox.Game/Sandbox.Game.csproj
@@ -536,6 +536,7 @@
     <Compile Include="Game\GameSystems\IMyOxygenBlock.cs" />
     <Compile Include="Game\GameSystems\IMyOxygenConsumer.cs" />
     <Compile Include="Game\GameSystems\IMyOxygenProducer.cs" />
+    <Compile Include="Game\GameSystems\IMyOxygenSharedSpace.cs" />
     <Compile Include="Game\GameSystems\MyAntennaSystem.cs" />
     <Compile Include="Engine\Utils\MyBattleHelper.cs" />
     <Compile Include="Game\GameSystems\MyChatSystem.cs" />

--- a/Sources/SpaceEngineers.Game/Entities/Blocks/MyMedicalRoom.cs
+++ b/Sources/SpaceEngineers.Game/Entities/Blocks/MyMedicalRoom.cs
@@ -464,6 +464,11 @@ namespace SpaceEngineers.Game.Entities.Blocks
             m_user.SuitOxygenAmount += amount;
         }
 
+        IMyOxygenSharedSpace IMyOxygenConsumer.GetSharedSpace()
+        {
+            return null;
+        }
+
         public void TryTakeSpawneeOwnership(MyPlayer player)
         {
             if (MySession.Static.IsScenario && m_takeSpawneeOwnership && Sync.IsServer && OwnerId == 0)


### PR DESCRIPTION


Problem: Significant oxygen loss can occur when multiple air vents are used to pressurize or depressurize a room.
http://forum.keenswh.com/threads/01-077-oxygen-loss-when-depressurize-a-room.7357431/

Cause: The current oxygen production/consumption algorithm queries air vents (all consumers/producers) without regard to which room they are attached to. Additionally, each air vent reports how much air it can use without regard to other vents attached to the same room. Finally, the possibility that an air vents requested oxygen amount could change as other vents are satisfied is neglected.

This leads to a problem when a room is near full (i.e. needs less than the air vents could supply in an update). If a room has X air vents and needs Y oxygen to be full, each of the air vents will request the full Y oxygen. A total of X\*Y oxygen is extracted from producers/tanks. When the fill process begins, the first air vent supplies Y oxygen to the room filling it. The remaining (X-1) air vents try to supply Y oxygen, but it is discarded in MyAirVent.Consume() because the room is already full, wasting (X-1)\*Y oxygen.

A similar event can happen when depressurizing (leading to the creation of oxygen).

Proposed solution: I have added the concept of a shared space (IMyOxygenShared) space from which producers pull and consumers add oxygen. I then reworked the oxygen consumption algorithm to sort consumers/producers into groups according what space they shared (if any), in addition to the pre-existing sorting by priority. Then it is ensured that producers never exceed the supply of and consumers never exceed the capacity of the space they share. Finally, if there is a production shortfall, the available supply is spread proportionally across all consumers in the priority level where supply has run out.

Although in some cases the structure of the code has be refactored (for DRY's sake), care has been taken to maintain the logic of the original algorithm wherever possible.

Testing performed: I have tested in a special creative world with 3 different room sizes from a single block to 7^3 blocks and with 1-10 air vents (where possible). With the patch in place, oxygen can be cycled between the room and an oxygen tank without noticeable loss/creation (to 6 significant digits). In 1.088.012, the same setups show variation up and down of the oxygen volume, with only the first significant digit remaining constant. Various basic operations were tested on a single room (various combinations of filling/emptying rooms/tanks/generators).