### PR TITLE
Fixed error with the way piston limits were saved.

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyPistonBase.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyPistonBase.cs
@@ -255,7 +255,7 @@ namespace Sandbox.Game.Entities.Blocks
 
         private float NormalizeDistance(float value)
         {
-            return (value + BlockDefinition.Minimum) / Range;
+            return (value - BlockDefinition.Minimum) / Range;
         }
 
         private float DenormalizeDistance(float value)


### PR DESCRIPTION
To reproduce the error, assign the ExtendedPistonBase object in cubeblocks.sbc a property &lt;Minimum&gt;5.0&lt;/Minimum&gt;. Then, in the game, set the minimum and/or maximum limit of a piston, save the game and reload. The limits restored will not be the same as what was saved.

I first found this error in code. To verify that it was an error, I edited the cubeblocks.sbc file as described and then tested saving and loading a piston with its minimum set to 7 and maximum set to 8. The minimum limit changed to 10 and the maximum limit changed to 17. I then applied my change and tested again. The error was no longer present.