### PR TITLE
FIX: projector detailed info update

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyProjectorBase.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyProjectorBase.cs
@@ -998,6 +998,7 @@ namespace Sandbox.Game.Entities.Blocks
         void previewGrid_OnBlockAdded(MySlimBlock obj)
         {
             m_shouldUpdateProjection = true;
+            m_shouldUpdateTexts = true; // text should be updated always, not only when terminal block is added
 
             //Update groups
             if (m_originalGridBuilder == null || !IsProjecting())
@@ -1050,7 +1051,6 @@ namespace Sandbox.Game.Entities.Blocks
                         }
                     }
                 }
-                m_shouldUpdateTexts = true;
             }
         }
 


### PR DESCRIPTION
ISSUE: when adding block that is not derived from terminal block (eg. armor, catwalk, and so on), detailed info is not updated, unless you exit and enter terminal, this affects also programmable block.
ISSUE2: when projector image is moved, detailed info is not updated on other clients after new offset is set, only projection is updated (in case of overlaying blocks, "welded" blocks are dedicted from projection, but text in projector stays unchanged)