### PR TITLE
Exposed IMyShipController inputs

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyShipController.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyShipController.cs
@@ -15,5 +15,13 @@ namespace Sandbox.ModAPI.Ingame
         bool ControlThrusters { get; }
         bool HandBrake { get; }
         bool DampenersOverride { get; }
+        /// <summary>
+        /// Returns the current translational/movement input from this controller relative to itself.
+        /// </summary>
+        VRageMath.Vector3 Translation { get; }
+        /// <summary>
+        /// Returns the current rotational input from this controller relative to itself while taking the roll dampener into account.
+        /// </summary>
+        VRageMath.Vector3 Rotation { get; }
     }
 }


### PR DESCRIPTION
The inputs of IMyShipController blocks can now be used with the ingame
programming API.
This allows for building your own ingame driver for thruster, gravity drives, robot arm remote controls, general 6-axis value inputs (i.e. slider for color/rotor velocity), custom build wheel and many more.

When a structure does not have power anymore, the old values will maintain.
The values however get updated even though the cockpit in question is not the main cockpit, ship controlls are disabled, there is no thruster or gyro grid system present etc.

Thus it can be used for pretty much everything as translation and rotation input from a cockpit.

Due to the "out of memory" issues with the source build i could not extensively test it but the normal KSH ships from the Easy Start worlds aswell as a few of my own ships behaved like before.

new properties:
- IMyShipController.Translation
- IMyShipController.Rotation