### PR TITLE
FIX: IMyTextPanel.WritePrivateText

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyTextPanel.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyTextPanel.cs
@@ -138,7 +138,7 @@ namespace Sandbox.Game.Entities.Blocks
             {
                 m_privateTitle.CompareUpdate(value);
 
-                if (m_privateTitle != value)
+                if (m_privateTitleHelper != value)
                 {
                     m_privateTitleHelper.Clear().Append(value);
                 }
@@ -152,7 +152,7 @@ namespace Sandbox.Game.Entities.Blocks
             {
                 m_descriptionChanged = m_privateDescription.CompareUpdate(value);
 
-                if (m_privateDescription != value)
+                if (m_privateDescriptionHelper != value)
                 {
                     m_privateDescriptionHelper.Clear().Append(value);
                 }


### PR DESCRIPTION
- due typo in code, variable was reset prior sending sync message, and text was reset, when using pb.