### PR TITLE
Prevent cluster split when object moves too far

### DIFF
--- a/Sources/VRage.Math/Spatial/MyClusterTree.cs
+++ b/Sources/VRage.Math/Spatial/MyClusterTree.cs
@@ -653,10 +653,16 @@ namespace VRageMath.Spatial
                         {
 
                             System.Diagnostics.Debug.Assert(aabb0.Max.GetDim(longestAxis) - minimumCluster.Min.GetDim(longestAxis) > 0, "Invalid minimal cluster");
-                            isClusterSplittable = true;
-
-                            currentMax.SetDim(longestAxis, aabb0.Max.GetDim(longestAxis));
-
+                            if (aabb0.Max.GetDim(longestAxis) - minimumCluster.Min.GetDim(longestAxis) > IdealClusterSize.GetDim(longestAxis))
+                            {
+                                // Distance is further than a cluster size, IOW object was teleported (eg jump drive)
+                                isClusterSplittable = false;
+                            }
+                            else
+                            {
+                                isClusterSplittable = true;
+                                currentMax.SetDim(longestAxis, aabb0.Max.GetDim(longestAxis));
+                            }
                             break;
                         }
                     }


### PR DESCRIPTION
This prevents a cluster split if the distance is greater than the ideal cluster size.
Fixes #158.

I recommend a lot of testing with this fix. I'm not sure it's the ideal fix, but it works.