### PR TITLE
LMB/RMB will act like T/K buttons if there is nothing selected in the current toolbar.

### DIFF
--- a/Sources/Sandbox.Game/Game/Screens/MyGuiScreenGamePlay.cs
+++ b/Sources/Sandbox.Game/Game/Screens/MyGuiScreenGamePlay.cs
@@ -402,7 +402,10 @@ namespace Sandbox.Game.Gui
 
                     if (context == MySpaceBindingCreator.CX_CHARACTER || context == MySpaceBindingCreator.CX_SPACESHIP)
                     {
-                        if (MyControllerHelper.IsControl(context, MyControlsSpace.USE, MyControlStateType.NEW_PRESSED))
+                        if (MyControllerHelper.IsControl(context, MyControlsSpace.USE, MyControlStateType.NEW_PRESSED) || 
+							(MyControllerHelper.IsControl(context, MyControlsSpace.PRIMARY_TOOL_ACTION, MyControlStateType.NEW_PRESSED) && 
+							!MyToolbarComponent.CurrentToolbar.SelectedSlot.HasValue &&
+							context == MySpaceBindingCreator.CX_CHARACTER))
                         {
                             // Key press
                             if (currentCameraController != null)
@@ -500,7 +503,10 @@ namespace Sandbox.Game.Gui
                         }
                     }
                 }
-                if (MyControllerHelper.IsControl(context, MyControlsSpace.TERMINAL, MyControlStateType.NEW_PRESSED) && MyGuiScreenGamePlay.ActiveGameplayScreen == null)
+                if ((MyControllerHelper.IsControl(context, MyControlsSpace.TERMINAL, MyControlStateType.NEW_PRESSED) && MyGuiScreenGamePlay.ActiveGameplayScreen == null) ||
+					(MyControllerHelper.IsControl(context, MyControlsSpace.SECONDARY_TOOL_ACTION, MyControlStateType.NEW_PRESSED) && 
+							!MyToolbarComponent.CurrentToolbar.SelectedSlot.HasValue &&
+							context == MySpaceBindingCreator.CX_CHARACTER))
                 {
                     MyGuiAudio.PlaySound(MyGuiSounds.HudClick);
                     controlledObject.ShowTerminal();


### PR DESCRIPTION
A simple feature suggested on [/r/spaceengineers](https://www.reddit.com/r/spaceengineers/comments/3dbe72/request_leftright_click_should_be_tk_when_nothing/) and got heavily upvoted.