### PR TITLE
FIX: missing mouse boundary check on click in UI control

### DIFF
--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlParent.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlParent.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using VRage.Utils;
 using VRageMath;
+using VRage.Input;
 
 namespace Sandbox.Graphics.GUI
 {
@@ -76,8 +77,15 @@ namespace Sandbox.Graphics.GUI
         public override MyGuiControlBase HandleInput()
         {
             MyGuiControlBase captured = null;
-            
+
             captured = base.HandleInput();
+
+            // if mouse is outside of parent, childs should not handle it
+            // keyboard still should be handled for possible text inputs or tabing switching controls
+            if (MyInput.Static.IsAnyMousePressed() && !IsMouseOver)
+            {
+                return null;
+            }
 
             foreach (var control in Controls.GetVisibleControls())
             {

--- a/Sources/Sandbox.Graphics/Gui/MyGuiControlParent.cs
+++ b/Sources/Sandbox.Graphics/Gui/MyGuiControlParent.cs
@@ -82,7 +82,7 @@ namespace Sandbox.Graphics.GUI
 
             // if mouse is outside of parent, childs should not handle it
             // keyboard still should be handled for possible text inputs or tabing switching controls
-            if (MyInput.Static.IsAnyMousePressed() && !IsMouseOver)
+            if ((MyInput.Static.IsAnyMousePressed() || MyControllerHelper.IsControl(MyControllerHelper.CX_GUI, MyControlsGUI.ACCEPT) && !IsMouseOver))
             {
                 return null;
             }


### PR DESCRIPTION
gist of the fix is, that any control that is derived from control parent (which seems to be every grouped control, like tab, list, listbox, grid, and so on), has aditional check for mouse position, when mouse button is pressed (and only when mouse button is presed). if mouse is inside control area, it will allow to forward input to child controls, if it's not, it will exit from input control handling.

please note, this check is already present, on some controls (like scrollable list), but grouped controls (like tab or grid), are missing this check.

due this missing check, if you have for example grid, with lot of controls inside, that needs to be scrolled, you can click on any control of the grid (even outside "visible area")

this should fix problem with unclickable tab controls in terminal, when you scroll down for example inventory list (reported on forums)

please note i have no controller, but might be, that for controller it will need to add aditional check.