### PR TITLE
Inventory Dupe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ user.props
 3rd/SteamSDK/release/x64
 3rd/VRage.Native/debug/x64
 3rd/VRage.Native/release/x64
+Report150726.vsp
+*.psess

--- a/Sources/Sandbox.Game/Game/Entities/Inventory/MyInventory.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Inventory/MyInventory.cs
@@ -193,7 +193,7 @@ namespace Sandbox.Game
             var adapter = MyInventoryItemAdapter.Static;
             adapter.Adapt(contentId);
 
-            if (MyPerGameSettings.ConstrainInventory() && (amount * adapter.Volume + m_currentVolume > MaxVolume) || (amount * adapter.Mass + m_currentMass > m_maxMass))
+            if (MyPerGameSettings.ConstrainInventory() && (amount * adapter.Volume + m_currentVolume >= MaxVolume) || (amount * adapter.Mass + m_currentMass > m_maxMass))
             {
                 return false;
             }

--- a/Sources/Sandbox.Game/Game/Entities/Inventory/MyInventory.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Inventory/MyInventory.cs
@@ -193,7 +193,7 @@ namespace Sandbox.Game
             var adapter = MyInventoryItemAdapter.Static;
             adapter.Adapt(contentId);
 
-            if (MyPerGameSettings.ConstrainInventory() && (amount * adapter.Volume + m_currentVolume >= MaxVolume) || (amount * adapter.Mass + m_currentMass > m_maxMass))
+            if (MyPerGameSettings.ConstrainInventory() && (amount * adapter.Volume + m_currentVolume >= MaxVolume) || (amount * adapter.Mass + m_currentMass >= m_maxMass))
             {
                 return false;
             }


### PR DESCRIPTION
When dragging and dropping an item in your inventory with a volume equal
to the space left your inventory, your character drops the item but it
stays in your inventory.

Example: Your inventory volume is 399/400. You have one computer (volume = 1) in one inventory slot. When you drag that one computer to other slots nothing in your inventory will change, but your character will drop one computer each time you try to drag the item to other slots.

