### PR TITLE
Fix programmable block crash to desktop

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
@@ -55,7 +55,7 @@ namespace Sandbox.Game.Entities.Blocks
         public bool ConsoleOpen = false;
         MyGuiScreenEditor m_editorScreen;
         Assembly m_assembly = null;
-        List<string> m_compilerErrors = new List<string>();
+        List<IlCompilerErrorMessage> m_compilerErrors = new List<IlCompilerErrorMessage>();
         private bool m_wasTerminated = false;
         private bool m_isRunning = false;
         private bool m_mainMethodSupportsArgument;

--- a/Sources/Sandbox.Game/Game/World/MyScriptManager.cs
+++ b/Sources/Sandbox.Game/Game/World/MyScriptManager.cs
@@ -37,7 +37,7 @@ namespace Sandbox.Game.World
 		public Dictionary<string, Type> StatScripts = new Dictionary<string, Type>();
         public Dictionary<MyStringId, Type> InGameScripts = new Dictionary<MyStringId, Type>(MyStringId.Comparer); //Ingame script is just game logic component
         public Dictionary<MyStringId, StringBuilder> InGameScriptsCode = new Dictionary<MyStringId, StringBuilder>(MyStringId.Comparer);
-        private List<string> m_errors = new List<string>();
+        private List<IlCompilerErrorMessage> m_errors = new List<IlCompilerErrorMessage>();
         private List<string> m_cachedFiles = new List<string>();
         static Dictionary<string, bool> testFiles = new Dictionary<string, bool>();
 

--- a/Sources/VRage.Library/Compiler/IlCompilerErrorInfo.cs
+++ b/Sources/VRage.Library/Compiler/IlCompilerErrorInfo.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace VRage.Compiler
+{
+    public struct IlCompilerErrorMessage
+    {
+        /// <summary>
+        /// Line number of the compiler error.
+        /// </summary>
+        public int? Line { get; private set; }
+
+        /// <summary>
+        /// Error text of the compiler error.
+        /// </summary>
+        public string Message { get; private set; }
+
+        /// <summary>
+        /// Creates a new <see cref="IlCompilerErrorMessage"/> instance.
+        /// </summary>
+        /// <param name="msg">Error message to show to the user.</param>
+        /// <param name="line">The line number of the error.</param>
+        public IlCompilerErrorMessage(string msg, int? line = null)
+            : this()
+        {
+            Line = line;
+            Message = msg;
+        }
+    }
+}

--- a/Sources/VRage.Library/VRage.Library.csproj
+++ b/Sources/VRage.Library/VRage.Library.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Collections\MyUniqueList.cs" />
     <Compile Include="Collections\SerializableDictionary.cs" />
     <Compile Include="Collections\StackReader.cs" />
+    <Compile Include="Compiler\IlCompilerErrorInfo.cs" />
     <Compile Include="Compiler\IlCompiler.cs" />
     <Compile Include="Compiler\IlInjector.cs" />
     <Compile Include="Compiler\TestScriptHelpers.cs" />


### PR DESCRIPTION
Fixes an unhandled ReflectionTypeLoadException in the programmable block compiler. The exception was thrown if a type of the compiled assembly can't be loaded.

Created IlCompilerErrorInfo to fix [hacky exception message parsing](https://github.com/KeenSoftwareHouse/SpaceEngineers/blob/ad0593cb7e201000282a5d8dcb20c773faf438a3/Sources/Sandbox.Game/Game/Screens/MyGuiScreenEditor.cs#L178) in MyGuiScreenEditor.

Fix #359 