### PR TITLE
Thruster manual boost

### DIFF
--- a/Sources/Sandbox.Game/Definitions/MyThrustDefinition.cs
+++ b/Sources/Sandbox.Game/Definitions/MyThrustDefinition.cs
@@ -19,6 +19,7 @@ namespace Sandbox.Definitions
         public float FlameLengthScale;
         public Vector4 FlameFullColor;
         public Vector4 FlameIdleColor;
+        public Vector4 FlameBoostColor;
         public string FlamePointMaterial;
         public string FlameLengthMaterial;
         public string FlameGlareMaterial;
@@ -41,6 +42,9 @@ namespace Sandbox.Definitions
             FlameLengthScale = thrustBuilder.FlameLengthScale;
             FlameFullColor = thrustBuilder.FlameFullColor;
             FlameIdleColor = thrustBuilder.FlameIdleColor;
+            FlameBoostColor = thrustBuilder.FlameBoostColor;
+            if (FlameBoostColor == Vector4.Zero)
+                FlameBoostColor = FlameFullColor;
             FlamePointMaterial = thrustBuilder.FlamePointMaterial;
             FlameLengthMaterial = thrustBuilder.FlameLengthMaterial;
             FlameGlareMaterial = thrustBuilder.FlameGlareMaterial;

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyThrust.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyThrust.cs
@@ -140,14 +140,25 @@ namespace Sandbox.Game.Entities
 
         public void UpdateThrustFlame()
         {
+            var thrustStrength = CurrentStrength;
+            if (thrustStrength > MyConstants.MAX_THRUST)
+                thrustStrength = MyConstants.MAX_THRUST;
+
             ThrustRadiusRand = MyUtils.GetRandomFloat(0.9f, 1.1f);
-            ThrustLengthRand = CurrentStrength * 10 * MyUtils.GetRandomFloat(0.6f, 1.0f) * m_thrustDefinition.FlameLengthScale;
+            ThrustLengthRand = thrustStrength * 10 * MyUtils.GetRandomFloat(0.6f, 1.0f) * m_thrustDefinition.FlameLengthScale;
             ThrustThicknessRand = MyUtils.GetRandomFloat(ThrustRadiusRand * 0.90f, ThrustRadiusRand);
         }
 
         public void UpdateThrustColor()
         {
-            m_thrustColor = Vector4.Lerp(m_thrustDefinition.FlameIdleColor, m_thrustDefinition.FlameFullColor, CurrentStrength / MyConstants.MAX_THRUST);
+            var thrustStrength = CurrentStrength;
+            if (thrustStrength > MyConstants.MAX_THRUST)
+                thrustStrength = MyConstants.MAX_THRUST;
+
+            if (thrustStrength <= 1.0f)
+                m_thrustColor = Vector4.Lerp(m_thrustDefinition.FlameIdleColor, m_thrustDefinition.FlameFullColor, thrustStrength / MyConstants.MAX_THRUST);
+            else
+                m_thrustColor = Vector4.Lerp(m_thrustDefinition.FlameFullColor, m_thrustDefinition.FlameBoostColor, (thrustStrength - 1.0f) / (MyConstants.MAX_THRUST - 1.0f));
             Light.Color = m_thrustColor;
         }
         public Vector4 ThrustColor { get { return m_thrustColor; } }
@@ -220,7 +231,7 @@ namespace Sandbox.Game.Entities
                 x.SyncObject.SendChangeThrustOverrideRequest(x.ThrustOverride); 
             };
             thrustOverride.DefaultValue = 0;
-            thrustOverride.SetLogLimits((x) => x.m_thrustDefinition.ForceMagnitude * 0.01f, (x) => x.m_thrustDefinition.ForceMagnitude);
+            thrustOverride.SetLogLimits((x) => x.m_thrustDefinition.ForceMagnitude * 0.0099f, (x) => x.m_thrustDefinition.ForceMagnitude * MyFakes.SLOWDOWN_FACTOR_THRUST_MULTIPLIER);
             thrustOverride.EnableActions();
             thrustOverride.Writer = (x, result) =>
                 {

--- a/Sources/Sandbox.Game/Game/GameSystems/MyGridThrustSystem.cs
+++ b/Sources/Sandbox.Game/Game/GameSystems/MyGridThrustSystem.cs
@@ -457,7 +457,7 @@ namespace Sandbox.Game.GameSystems
                     {
                         m_totalThrustOverride += thrust.ThrustOverride * -thrust.ThrustForwardVector;
                         minRequiredPower += thrust.MinPowerConsumption;
-                        m_totalThrustOverridePower += thrust.ThrustOverride / thrust.ThrustForce.Length() * thrust.MaxPowerConsumption;
+                        m_totalThrustOverridePower += MathHelper.Clamp(thrust.ThrustOverride / thrust.ThrustForce.Length() * thrust.MaxPowerConsumption, 0.0f, thrust.MaxPowerConsumption * MyConstants.MAX_THRUST);
                         continue;
                     }
 

--- a/Sources/SpaceEngineers/Content/Data/CubeBlocks.sbc
+++ b/Sources/SpaceEngineers/Content/Data/CubeBlocks.sbc
@@ -17204,6 +17204,12 @@
         <Z>0.6505882</Z>
         <W>0.75</W>
       </FlameFullColor>
+      <FlameBoostColor>
+        <X>0.9</X>
+        <Y>0.7</Y>
+        <Z>0.2</Z>
+        <W>0.95</W>
+      </FlameBoostColor>
       <FlamePointMaterial>EngineThrustMiddle</FlamePointMaterial>
       <FlameLengthMaterial>EngineThrustMiddle</FlameLengthMaterial>
       <FlameGlareMaterial>GlareSsThrustSmall</FlameGlareMaterial>
@@ -17269,6 +17275,12 @@
         <Z>0.6505882</Z>
         <W>0.75</W>
       </FlameFullColor>
+      <FlameBoostColor>
+        <X>0.9</X>
+        <Y>0.7</Y>
+        <Z>0.2</Z>
+        <W>0.95</W>
+      </FlameBoostColor>
       <FlamePointMaterial>EngineThrustMiddle</FlamePointMaterial>
       <FlameLengthMaterial>EngineThrustMiddle</FlameLengthMaterial>
       <FlameGlareMaterial>GlareSsThrustLarge</FlameGlareMaterial>
@@ -17333,6 +17345,12 @@
         <Z>0.6505882</Z>
         <W>0.75</W>
       </FlameFullColor>
+      <FlameBoostColor>
+        <X>0.9</X>
+        <Y>0.7</Y>
+        <Z>0.2</Z>
+        <W>0.95</W>
+      </FlameBoostColor>
       <FlamePointMaterial>EngineThrustMiddle</FlamePointMaterial>
       <FlameLengthMaterial>EngineThrustMiddle</FlameLengthMaterial>
       <FlameGlareMaterial>GlareLsThrustSmall</FlameGlareMaterial>
@@ -17398,6 +17416,12 @@
         <Z>0.6505882</Z>
         <W>0.75</W>
       </FlameFullColor>
+      <FlameBoostColor>
+        <X>0.9</X>
+        <Y>0.7</Y>
+        <Z>0.2</Z>
+        <W>0.95</W>
+      </FlameBoostColor>
       <FlamePointMaterial>EngineThrustMiddle</FlamePointMaterial>
       <FlameLengthMaterial>EngineThrustMiddle</FlameLengthMaterial>
       <FlameGlareMaterial>GlareLsThrustLarge</FlameGlareMaterial>

--- a/Sources/VRage.Game/ObjectBuilders/Definitions/MyObjectBuilder_ThrustDefinition.cs
+++ b/Sources/VRage.Game/ObjectBuilders/Definitions/MyObjectBuilder_ThrustDefinition.cs
@@ -32,6 +32,9 @@ namespace Sandbox.Common.ObjectBuilders.Definitions
         public Vector4 FlameIdleColor = DefaultThrustColor;
 
         [ProtoMember]
+        public Vector4 FlameBoostColor = Vector4.Zero;
+
+        [ProtoMember]
         public string FlamePointMaterial = "EngineThrustMiddle";
 
         [ProtoMember]


### PR DESCRIPTION
This pull request does 2 things:
* First, it extends the range of "Thrust override" slider, so that TurboBoost feature -- which is restricted to braking in vanilla version -- can be used for acceleration as well,
* Secondly, it adds a new "FlameBoostColor" tag to CubeBlocks.sbc. This tag allows to specify different flame colour for thruster operating in TurboBoost mode. If omitted, the tag defaults to "FlameFullColor" value.