### PR TITLE
New raycast method

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/IMyEntities.cs
+++ b/Sources/Sandbox.Common/ModAPI/IMyEntities.cs
@@ -35,6 +35,7 @@ namespace Sandbox.ModAPI
         float WorldSafeHalfExtent();
         bool IsInsideWorld(Vector3D pos);
         bool IsRaycastBlocked(Vector3D pos, Vector3D target);
+        Vector3D? ClosestRayIntersection(Vector3D pos, Vector3D target);
         void SetEntityName(IMyEntity IMyEntity, bool possibleRename = true);
         bool IsNameExists(IMyEntity entity, string name);
         void RemoveFromClosedEntities(IMyEntity entity);

--- a/Sources/Sandbox.Common/ModAPI/IMyEntities.cs
+++ b/Sources/Sandbox.Common/ModAPI/IMyEntities.cs
@@ -35,7 +35,6 @@ namespace Sandbox.ModAPI
         float WorldSafeHalfExtent();
         bool IsInsideWorld(Vector3D pos);
         bool IsRaycastBlocked(Vector3D pos, Vector3D target);
-        Vector3D? ClosestRayIntersection(Vector3D pos, Vector3D target);
         void SetEntityName(IMyEntity IMyEntity, bool possibleRename = true);
         bool IsNameExists(IMyEntity entity, string name);
         void RemoveFromClosedEntities(IMyEntity entity);

--- a/Sources/Sandbox.Game/Engine/Physics/MyPhysics.cs
+++ b/Sources/Sandbox.Game/Engine/Physics/MyPhysics.cs
@@ -779,8 +779,42 @@ namespace Sandbox.Engine.Physics
                     );
                 }
             }
+            m_resultWorlds.Clear();
+        }
+
+        public static Vector3D? CastRay(Vector3D from, Vector3D to, int raycastFilterLayer = 0)
+        {
+            Vector3D? MinPos = null;
+            double MinDist = double.PositiveInfinity;
 
             m_resultWorlds.Clear();
+            Clusters.CastRay(from, to, m_resultWorlds);
+
+            foreach (var world in m_resultWorlds)
+            {
+                Vector3D Position;
+                Vector3 fromF = from - world.AABB.Center;
+                Vector3 toF = to - world.AABB.Center;
+
+                m_resultHits.Clear();
+                ((HkWorld)world.UserData).CastRay(fromF, toF, m_resultHits, raycastFilterLayer);
+
+                foreach (var hit in m_resultHits)
+                {
+                    Position = hit.Position + world.AABB.Center;
+                    double dist = (Position-from).Length();
+                    if (dist < MinDist)
+                    {
+                        MinDist = dist;
+                        MinPos = Position;
+                    }
+                }
+                m_resultHits.Clear();
+            }
+
+            m_resultWorlds.Clear();
+
+            return MinPos;
         }
 
         public static HkRigidBody CastRay(Vector3D from, Vector3D to, out Vector3D position, out Vector3 normal, int raycastFilterLayer = 0)

--- a/Sources/Sandbox.Game/Engine/Physics/MyPhysics.cs
+++ b/Sources/Sandbox.Game/Engine/Physics/MyPhysics.cs
@@ -779,42 +779,8 @@ namespace Sandbox.Engine.Physics
                     );
                 }
             }
-            m_resultWorlds.Clear();
-        }
-
-        public static Vector3D? CastRay(Vector3D from, Vector3D to, int raycastFilterLayer = 0)
-        {
-            Vector3D? MinPos = null;
-            double MinDist = double.PositiveInfinity;
 
             m_resultWorlds.Clear();
-            Clusters.CastRay(from, to, m_resultWorlds);
-
-            foreach (var world in m_resultWorlds)
-            {
-                Vector3D Position;
-                Vector3 fromF = from - world.AABB.Center;
-                Vector3 toF = to - world.AABB.Center;
-
-                m_resultHits.Clear();
-                ((HkWorld)world.UserData).CastRay(fromF, toF, m_resultHits, raycastFilterLayer);
-
-                foreach (var hit in m_resultHits)
-                {
-                    Position = hit.Position + world.AABB.Center;
-                    double dist = (Position-from).Length();
-                    if (dist < MinDist)
-                    {
-                        MinDist = dist;
-                        MinPos = Position;
-                    }
-                }
-                m_resultHits.Clear();
-            }
-
-            m_resultWorlds.Clear();
-
-            return MinPos;
         }
 
         public static HkRigidBody CastRay(Vector3D from, Vector3D to, out Vector3D position, out Vector3 normal, int raycastFilterLayer = 0)

--- a/Sources/Sandbox.Game/Game/Entities/MyEntities.cs
+++ b/Sources/Sandbox.Game/Game/Entities/MyEntities.cs
@@ -297,6 +297,15 @@ namespace Sandbox.Game.Entities
         }
 
         /// <summary>
+        /// Check if ray is blocked and return the "blocking" position
+        /// </summary>
+        /// <returns>null if not blocked otherwise the intersection between the ray and the closest blocker</returns>
+        public static Vector3D? ClosestRayIntersection(Vector3D pos, Vector3D target)
+        {
+            return MyPhysics.CastRay(pos, target);
+        }
+
+        /// <summary>
         /// Get all rigid body elements touching a bounding box.
         /// Clear() the result list after you're done with it!
         /// </summary>

--- a/Sources/Sandbox.Game/Game/Entities/MyEntities.cs
+++ b/Sources/Sandbox.Game/Game/Entities/MyEntities.cs
@@ -297,15 +297,6 @@ namespace Sandbox.Game.Entities
         }
 
         /// <summary>
-        /// Check if ray is blocked and return the "blocking" position
-        /// </summary>
-        /// <returns>null if not blocked otherwise the intersection between the ray and the closest blocker</returns>
-        public static Vector3D? ClosestRayIntersection(Vector3D pos, Vector3D target)
-        {
-            return MyPhysics.CastRay(pos, target);
-        }
-
-        /// <summary>
         /// Get all rigid body elements touching a bounding box.
         /// Clear() the result list after you're done with it!
         /// </summary>

--- a/Sources/Sandbox.Game/ModAPI/MyEntitiesHelper_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/MyEntitiesHelper_ModAPI.cs
@@ -141,11 +141,6 @@ namespace Sandbox.ModAPI
             return MyEntities.IsRaycastBlocked(pos, target);
         }
 
-        VRageMath.Vector3D? IMyEntities.ClosestRayIntersection(VRageMath.Vector3D pos, VRageMath.Vector3D target)
-        {
-            return MyEntities.ClosestRayIntersection(pos, target);
-        }
-
         List<IMyEntity> IMyEntities.GetEntitiesInAABB(ref VRageMath.BoundingBoxD boundingBox)
         {
             var lst = MyEntities.GetEntitiesInAABB(ref boundingBox);

--- a/Sources/Sandbox.Game/ModAPI/MyEntitiesHelper_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/MyEntitiesHelper_ModAPI.cs
@@ -141,6 +141,11 @@ namespace Sandbox.ModAPI
             return MyEntities.IsRaycastBlocked(pos, target);
         }
 
+        VRageMath.Vector3D? IMyEntities.ClosestRayIntersection(VRageMath.Vector3D pos, VRageMath.Vector3D target)
+        {
+            return MyEntities.ClosestRayIntersection(pos, target);
+        }
+
         List<IMyEntity> IMyEntities.GetEntitiesInAABB(ref VRageMath.BoundingBoxD boundingBox)
         {
             var lst = MyEntities.GetEntitiesInAABB(ref boundingBox);


### PR DESCRIPTION
Added IMyEntites.ClosestRayIntersection, a modification of the
IsRayCastBlocked method.
Returns null if no intersection otherwise the location (Vector3D) of the
closest intersection of the ray.
Reduces Gamelogic time by up to 2ms when used by my rangefinder mod
compared to the current solution using several raycast methods on lotsa
different objects.

Now from a branch, hope that's good now.