### PR TITLE
FIX: Terminal property extension GetMinimum

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Interfaces/ITerminalProperty.cs
+++ b/Sources/Sandbox.Common/ModAPI/Interfaces/ITerminalProperty.cs
@@ -8,29 +8,88 @@ using VRageMath;
 
 namespace Sandbox.ModAPI.Interfaces
 {
+    /// <summary>
+    /// Terminal block property definition
+    /// </summary>
     public interface ITerminalProperty
     {
+        /// <summary>
+        /// Property Id (value name)
+        /// </summary>
         string Id { get; }
+        /// <summary>
+        /// Property type (bool - <see cref="bool"/>, float - <see cref="float"/>, color - <see cref="VRageMath.Color"/>)
+        /// </summary>
         string TypeName { get; }
     }
 
+    /// <summary>
+    /// Terminal block property access
+    /// </summary>
+    /// <typeparam name="TValue">Property type (<see cref="ITerminalProperty.TypeName"/>)</typeparam>
     public interface ITerminalProperty<TValue> : ITerminalProperty
     {
+        /// <summary>
+        /// Retrieve property value
+        /// </summary>
+        /// <param name="block">block reference</param>
+        /// <returns>value of type <see cref="ITerminalProperty.TypeName"/></returns>
         TValue GetValue(Sandbox.ModAPI.Ingame.IMyCubeBlock block);
+        /// <summary>
+        /// Set property value
+        /// </summary>
+        /// <param name="block">block reference</param>
+        /// <param name="value">value of type <see cref="ITerminalProperty.TypeName"/></param>
         void SetValue(Sandbox.ModAPI.Ingame.IMyCubeBlock block, TValue value);
 
+        /// <summary>
+        /// Default value of property (if value is not set, or value from block definition)
+        /// </summary>
+        /// <param name="block">block reference</param>
+        /// <returns>value of type <see cref="ITerminalProperty.TypeName"/></returns>
         TValue GetDefaultValue(Sandbox.ModAPI.Ingame.IMyCubeBlock block);
+        /// <summary>
+        /// Minimum value of property (value from block definition) - this function is obsolete, because it contains typo in name
+        /// </summary>
+        /// <param name="block">block reference</param>
+        /// <returns>value of type <see cref="ITerminalProperty.TypeName"/></returns>
+        [Obsolete]
         TValue GetMininum(Sandbox.ModAPI.Ingame.IMyCubeBlock block);
+        /// <summary>
+        /// Minimum value of property (value from block definition)
+        /// </summary>
+        /// <param name="block">block reference</param>
+        /// <returns>value of type <see cref="ITerminalProperty.TypeName"/></returns>
+        TValue GetMinimum(Sandbox.ModAPI.Ingame.IMyCubeBlock block);
+        /// <summary>
+        /// Maximum value of property (value from block definition)
+        /// </summary>
+        /// <param name="block">block reference</param>
+        /// <returns>value of type <see cref="ITerminalProperty.TypeName"/></returns>
         TValue GetMaximum(Sandbox.ModAPI.Ingame.IMyCubeBlock block);
     }
 
+    /// <summary>
+    /// Terminal block extension for property access
+    /// </summary>
     public static class TerminalPropertyExtensions
     {
+        /// <summary>
+        /// Property type cast
+        /// </summary>
+        /// <typeparam name="TValue">value of type <see cref="ITerminalProperty.TypeName"/></typeparam>
+        /// <param name="property"><see cref="ITerminalProperty{TValue}"/> reference</param>
+        /// <returns>reference to <see cref="ITerminalProperty{TValue}"/> value of specified type</returns>
         public static ITerminalProperty<TValue> As<TValue>(this ITerminalProperty property)
         {
             return property as ITerminalProperty<TValue>;
         }
-
+        /// <summary>
+        /// Property type cast
+        /// </summary>
+        /// <typeparam name="TValue">value of type <see cref="ITerminalProperty.TypeName"/></typeparam>
+        /// <param name="property"><see cref="ITerminalProperty{TValue}"/> reference</param>
+        /// <returns>reference to <see cref="ITerminalProperty{TValue}"/> value of specified type</returns>
         public static ITerminalProperty<TValue> Cast<TValue>(this ITerminalProperty property)
         {
             var prop = property.As<TValue>();
@@ -39,69 +98,172 @@ namespace Sandbox.ModAPI.Interfaces
             return prop;
         }
 
+        /// <summary>
+        /// Check property type
+        /// </summary>
+        /// <typeparam name="TValue">value of type <see cref="ITerminalProperty.TypeName"/></typeparam>
+        /// <param name="property"><see cref="ITerminalProperty{TValue}"/> reference</param>
+        /// <returns>true if type matches</returns>
         public static bool Is<TValue>(this ITerminalProperty property)
         {
             return property is ITerminalProperty<TValue>;
         }
-
+        /// <summary>
+        /// Property type cast
+        /// </summary>
+        /// <param name="property"><see cref="ITerminalProperty{TValue}"/> reference</param>
+        /// <returns>reference to <see cref="ITerminalProperty{TValue}"/> value of specified type (float)</returns>
         public static ITerminalProperty<float> AsFloat(this ITerminalProperty property)
         {
             return property.As<float>();
         }
-
+        /// <summary>
+        /// Property type cast
+        /// </summary>
+        /// <param name="property"><see cref="ITerminalProperty{TValue}"/> reference</param>
+        /// <returns>reference to <see cref="ITerminalProperty{TValue}"/> value of specified type (Color)</returns>
         public static ITerminalProperty<Color> AsColor(this ITerminalProperty property)
         {
             return property.As<Color>();
         }
-
+        /// <summary>
+        /// Property type cast
+        /// </summary>
+        /// <param name="property"><see cref="ITerminalProperty{TValue}"/> reference</param>
+        /// <returns>reference to <see cref="ITerminalProperty{TValue}"/> value of specified type (bool)</returns>
         public static ITerminalProperty<bool> AsBool(this ITerminalProperty property)
         {
             return property.As<bool>();
         }
-
+        /// <summary>
+        /// Returns value of specified property
+        /// </summary>
+        /// <param name="block">block reference</param>
+        /// <param name="propertyId">property id (name)</param>
+        /// <returns>property value as float</returns>
         public static float GetValueFloat(this Ingame.IMyTerminalBlock block, string propertyId)
         {
             return block.GetValue<float>(propertyId);
         }
-
+        /// <summary>
+        /// Set float value of property
+        /// </summary>
+        /// <typeparam name="T"><see cref="ITerminalProperty.TypeName"/></typeparam>
+        /// <param name="block">block reference</param>
+        /// <param name="propertyId">property id (name)</param>
+        /// <param name="value">value to set</param>
         public static void SetValueFloat(this Ingame.IMyTerminalBlock block, string propertyId, float value)
         {
             block.SetValue<float>(propertyId, value);
         }
-
+        /// <summary>
+        /// Returns value of specified property
+        /// </summary>
+        /// <param name="block">block reference</param>
+        /// <param name="propertyId">property id (name)</param>
+        /// <returns>property value as bool</returns>
         public static bool GetValueBool(this Ingame.IMyTerminalBlock block, string propertyId)
         {
             return block.GetValue<bool>(propertyId);
         }
-
+        /// <summary>
+        /// Set bool value of property
+        /// </summary>
+        /// <typeparam name="T"><see cref="ITerminalProperty.TypeName"/></typeparam>
+        /// <param name="block">block reference</param>
+        /// <param name="propertyId">property id (name)</param>
+        /// <param name="value">value to set</param>
         public static void SetValueBool(this Ingame.IMyTerminalBlock block, string propertyId, bool value)
         {
             block.SetValue<bool>(propertyId, value);
         }
-
-        public static void SetValue<T>(this Ingame.IMyTerminalBlock block, string propertyId, T value)
+        /// <summary>
+        /// Returns value of specified property
+        /// </summary>
+        /// <param name="block">block reference</param>
+        /// <param name="propertyId">property id (name)</param>
+        /// <returns>property value as Color</returns>
+        public static Color GetValueColor(this Ingame.IMyTerminalBlock block, string propertyId)
         {
-            block.GetProperty(propertyId).Cast<T>().SetValue(block, value);
+            return block.GetValue<Color>(propertyId);
         }
-
+        /// <summary>
+        /// Set bool value of property
+        /// </summary>
+        /// <typeparam name="T"><see cref="ITerminalProperty.TypeName"/></typeparam>
+        /// <param name="block">block reference</param>
+        /// <param name="propertyId">property id (name)</param>
+        /// <param name="value">value to set</param>
+        public static void SetValueColor(this Ingame.IMyTerminalBlock block, string propertyId, Color value)
+        {
+            block.SetValue<Color>(propertyId, value);
+        }
+        /// <summary>
+        /// Returns value of specified property as <see cref="ITerminalProperty.TypeName"/>
+        /// </summary>
+        /// <typeparam name="T">required value type of <see cref="ITerminalProperty.TypeName"/></typeparam>
+        /// <param name="block">block reference</param>
+        /// <param name="propertyId">property id (name)</param>
+        /// <returns>property value as <see cref="ITerminalProperty.TypeName"/></returns>
         public static T GetValue<T>(this Ingame.IMyTerminalBlock block, string propertyId)
         {
             return block.GetProperty(propertyId).Cast<T>().GetValue(block);
         }
-
+        /// <summary>
+        /// Returns default value of specified property as <see cref="ITerminalProperty.TypeName"/>
+        /// </summary>
+        /// <typeparam name="T">required value type of <see cref="ITerminalProperty.TypeName"/></typeparam>
+        /// <param name="block">block reference</param>
+        /// <param name="propertyId">property id (name)</param>
+        /// <returns>property value as <see cref="ITerminalProperty.TypeName"/></returns>
         public static T GetDefaultValue<T>(this Ingame.IMyTerminalBlock block, string propertyId)
         {
             return block.GetProperty(propertyId).Cast<T>().GetDefaultValue(block);
         }
-
+        /// <summary>
+        /// Returns minimum value of specified property as <see cref="ITerminalProperty.TypeName"/> - this call is obsolete due typo in name
+        /// </summary>
+        /// <typeparam name="T">required value type of <see cref="ITerminalProperty.TypeName"/></typeparam>
+        /// <param name="block">block reference</param>
+        /// <param name="propertyId">property id (name)</param>
+        /// <returns>property value as <see cref="ITerminalProperty.TypeName"/></returns>
+        [Obsolete]
         public static T GetMininum<T>(this Ingame.IMyTerminalBlock block, string propertyId)
         {
-            return block.GetProperty(propertyId).Cast<T>().GetMininum(block);
+            return block.GetProperty(propertyId).Cast<T>().GetMinimum(block);
         }
-
+        /// <summary>
+        /// Returns minimum value of specified property as <see cref="ITerminalProperty.TypeName"/>
+        /// </summary>
+        /// <typeparam name="T">required value type of <see cref="ITerminalProperty.TypeName"/></typeparam>
+        /// <param name="block">block reference</param>
+        /// <param name="propertyId">property id (name)</param>
+        /// <returns>property value as <see cref="ITerminalProperty.TypeName"/></returns>
+        public static T GetMinimum<T>(this Ingame.IMyTerminalBlock block, string propertyId)
+        {
+            return block.GetProperty(propertyId).Cast<T>().GetMinimum(block);
+        }
+        /// <summary>
+        /// Returns maximum value of specified property as <see cref="ITerminalProperty.TypeName"/>
+        /// </summary>
+        /// <typeparam name="T">required value type of <see cref="ITerminalProperty.TypeName"/></typeparam>
+        /// <param name="block">block reference</param>
+        /// <param name="propertyId">property id (name)</param>
+        /// <returns>property value as <see cref="ITerminalProperty.TypeName"/></returns>
         public static T GetMaximum<T>(this Ingame.IMyTerminalBlock block, string propertyId)
         {
             return block.GetProperty(propertyId).Cast<T>().GetMaximum(block);
+        }
+        /// <summary>
+        /// Set value of property with type of <see cref="ITerminalProperty.TypeName"/>
+        /// </summary>
+        /// <typeparam name="T"><see cref="ITerminalProperty.TypeName"/></typeparam>
+        /// <param name="block">block reference</param>
+        /// <param name="propertyId">property id (name)</param>
+        /// <param name="value">value to set</param>
+        public static void SetValue<T>(this Ingame.IMyTerminalBlock block, string propertyId, T value)
+        {
+            block.GetProperty(propertyId).Cast<T>().SetValue(block, value);
         }
     }
 }

--- a/Sources/Sandbox.Common/ModAPI/Interfaces/ITerminalProperty.cs
+++ b/Sources/Sandbox.Common/ModAPI/Interfaces/ITerminalProperty.cs
@@ -49,7 +49,7 @@ namespace Sandbox.ModAPI.Interfaces
         /// <returns>value of type <see cref="ITerminalProperty.TypeName"/></returns>
         TValue GetDefaultValue(Sandbox.ModAPI.Ingame.IMyCubeBlock block);
         /// <summary>
-        /// Minimum value of property (value from block definition) - this function is obsolete, because it contains typo in name
+        /// Minimum value of property (value from block definition) - this function is obsolete, because it contains typo in name, use <see cref="GetMinimum(Sandbox.ModAPI.Ingame.IMyCubeBlock)"/>
         /// </summary>
         /// <param name="block">block reference</param>
         /// <returns>value of type <see cref="ITerminalProperty.TypeName"/></returns>
@@ -221,7 +221,7 @@ namespace Sandbox.ModAPI.Interfaces
             return block.GetProperty(propertyId).Cast<T>().GetDefaultValue(block);
         }
         /// <summary>
-        /// Returns minimum value of specified property as <see cref="ITerminalProperty.TypeName"/> - this call is obsolete due typo in name
+        /// Returns minimum value of specified property as <see cref="ITerminalProperty.TypeName"/> - this call is obsolete due typo in name, use <see cref="GetMinimum{T}(Ingame.IMyTerminalBlock, string)"/>
         /// </summary>
         /// <typeparam name="T">required value type of <see cref="ITerminalProperty.TypeName"/></typeparam>
         /// <param name="block">block reference</param>

--- a/Sources/Sandbox.Common/ModAPI/Interfaces/ITerminalProperty.cs
+++ b/Sources/Sandbox.Common/ModAPI/Interfaces/ITerminalProperty.cs
@@ -53,7 +53,7 @@ namespace Sandbox.ModAPI.Interfaces
         /// </summary>
         /// <param name="block">block reference</param>
         /// <returns>value of type <see cref="ITerminalProperty.TypeName"/></returns>
-        [Obsolete]
+        [Obsolete("Use GetMinimum instead")]
         TValue GetMininum(Sandbox.ModAPI.Ingame.IMyCubeBlock block);
         /// <summary>
         /// Minimum value of property (value from block definition)
@@ -227,7 +227,7 @@ namespace Sandbox.ModAPI.Interfaces
         /// <param name="block">block reference</param>
         /// <param name="propertyId">property id (name)</param>
         /// <returns>property value as <see cref="ITerminalProperty.TypeName"/></returns>
-        [Obsolete]
+        [Obsolete("Use GetMinimum instead")]
         public static T GetMininum<T>(this Ingame.IMyTerminalBlock block, string propertyId)
         {
             return block.GetProperty(propertyId).Cast<T>().GetMinimum(block);

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/ITerminalValueControl.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/ITerminalValueControl.cs
@@ -16,6 +16,7 @@ namespace Sandbox.Game.Screens.Terminal.Controls
         void SetValue(TBlock block, TValue value);
 
         TValue GetDefaultValue(TBlock block);
+        [Obsolete("Use GetMinimum instead")]
         TValue GetMininum(TBlock block);
         TValue GetMinimum(TBlock block);
         TValue GetMaximum(TBlock block);

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/ITerminalValueControl.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/ITerminalValueControl.cs
@@ -17,6 +17,7 @@ namespace Sandbox.Game.Screens.Terminal.Controls
 
         TValue GetDefaultValue(TBlock block);
         TValue GetMininum(TBlock block);
+        TValue GetMinimum(TBlock block);
         TValue GetMaximum(TBlock block);
 
         void Serialize(BitStream stream, TBlock block);

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlCheckbox.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlCheckbox.cs
@@ -99,6 +99,11 @@ namespace Sandbox.Game.Gui
 
         public override bool GetMininum(TBlock block)
         {
+            return GetMinimum(block);
+        }
+
+        public override bool GetMinimum(TBlock block)
+        {
             return false;
         }
 

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlCheckbox.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlCheckbox.cs
@@ -97,11 +97,6 @@ namespace Sandbox.Game.Gui
             return false;
         }
 
-        public override bool GetMininum(TBlock block)
-        {
-            return GetMinimum(block);
-        }
-
         public override bool GetMinimum(TBlock block)
         {
             return false;

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlColor.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlColor.cs
@@ -68,11 +68,6 @@ namespace Sandbox.Game.Gui
             return new Color(Vector4.One);
         }
 
-        public override Color GetMininum(TBlock block)
-        {
-            return GetMinimum(block);
-        }
-
         public override Color GetMinimum(TBlock block)
         {
             return new Color(Vector4.Zero);

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlColor.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlColor.cs
@@ -70,6 +70,11 @@ namespace Sandbox.Game.Gui
 
         public override Color GetMininum(TBlock block)
         {
+            return GetMinimum(block);
+        }
+
+        public override Color GetMinimum(TBlock block)
+        {
             return new Color(Vector4.Zero);
         }
 

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlOnOffSwitch.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlOnOffSwitch.cs
@@ -133,11 +133,6 @@ namespace Sandbox.Game.Gui
             return false;
         }
 
-        public override bool GetMininum(TBlock block)
-        {
-            return GetMinimum(block);
-        }
-
         public override bool GetMinimum(TBlock block)
         {
             return false;

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlOnOffSwitch.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlOnOffSwitch.cs
@@ -135,6 +135,11 @@ namespace Sandbox.Game.Gui
 
         public override bool GetMininum(TBlock block)
         {
+            return GetMinimum(block);
+        }
+
+        public override bool GetMinimum(TBlock block)
+        {
             return false;
         }
 

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlSlider.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlSlider.cs
@@ -317,6 +317,11 @@ namespace Sandbox.Game.Gui
 
         public override float GetMininum(TBlock block)
         {
+            return GetMinimum(block);
+        }
+
+        public override float GetMinimum(TBlock block)
+        {
             return Denormalizer(block, 0);
         }
 

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlSlider.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlSlider.cs
@@ -315,11 +315,6 @@ namespace Sandbox.Game.Gui
             return DefaultValueGetter(block);
         }
 
-        public override float GetMininum(TBlock block)
-        {
-            return GetMinimum(block);
-        }
-
         public override float GetMinimum(TBlock block)
         {
             return Denormalizer(block, 0);

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalValueControl.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalValueControl.cs
@@ -77,7 +77,11 @@ namespace Sandbox.Game.Screens.Terminal.Controls
         }
 
         public abstract TValue GetDefaultValue(TBlock block);
-        public abstract TValue GetMininum(TBlock block);
+        [Obsolete("Use GetMinimum instead")]
+        public TValue GetMininum(TBlock block)
+        {
+            return GetMinimum(block);
+        }
         public abstract TValue GetMinimum(TBlock block);
         public abstract TValue GetMaximum(TBlock block);
 

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalValueControl.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalValueControl.cs
@@ -100,6 +100,7 @@ namespace Sandbox.Game.Screens.Terminal.Controls
             return GetDefaultValue(((TBlock)block));
         }
 
+        [Obsolete("Use GetMinimum instead")]
         public TValue GetMininum(ModAPI.Ingame.IMyCubeBlock block)
         {
             return GetMinimum(((TBlock)block));

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalValueControl.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalValueControl.cs
@@ -78,6 +78,7 @@ namespace Sandbox.Game.Screens.Terminal.Controls
 
         public abstract TValue GetDefaultValue(TBlock block);
         public abstract TValue GetMininum(TBlock block);
+        public abstract TValue GetMinimum(TBlock block);
         public abstract TValue GetMaximum(TBlock block);
 
         public TValue GetValue(ModAPI.Ingame.IMyCubeBlock block)
@@ -97,7 +98,12 @@ namespace Sandbox.Game.Screens.Terminal.Controls
 
         public TValue GetMininum(ModAPI.Ingame.IMyCubeBlock block)
         {
-            return GetMininum(((TBlock)block));
+            return GetMinimum(((TBlock)block));
+        }
+
+        public TValue GetMinimum(ModAPI.Ingame.IMyCubeBlock block)
+        {
+            return GetMinimum(((TBlock)block));
         }
 
         public TValue GetMaximum(ModAPI.Ingame.IMyCubeBlock block)


### PR DESCRIPTION
Added missing GetMinimum to ITerminalProperty and TerminalPropertyExtension
Marked existing GetMininum as obsolete (not removing this function, since it might break existing scripts)