### PR TITLE
FIX: All inventories fail to move items within the same inventory.

### DIFF
--- a/Sources/Sandbox.Game/Game/Multiplayer/MySyncInventory.cs
+++ b/Sources/Sandbox.Game/Game/Multiplayer/MySyncInventory.cs
@@ -526,12 +526,29 @@ namespace Sandbox.Game.Multiplayer
 
             FixTransferAmount(src, dst, srcItem, spawn, ref remove, ref amount);
 
-            if (amount != 0)
+            if (src != dst)
             {
-                if (dst.AddItems(amount, srcItem.Value.Content, destItemIndex))
+                // If it's not the same source and destination inventory then add the items to the new inventory first and then remove them from the old one
+                if (amount != 0)
+                {
+                    if (dst.AddItems(amount, srcItem.Value.Content, destItemIndex))
+                    {
+                        if (remove != 0)
+                            src.RemoveItems(itemId, remove);
+                    }
+                }
+            }
+            else
+            {
+                // If it's the same inventory then remove the items first and then add them to the new position.
+                if (amount != 0)
                 {
                     if (remove != 0)
+                    {
                         src.RemoveItems(itemId, remove);
+                    }
+
+                    dst.AddItems(amount, srcItem.Value.Content, destItemIndex);
                 }
             }
         }

--- a/Sources/Sandbox.Game/Game/Multiplayer/MySyncInventory.cs
+++ b/Sources/Sandbox.Game/Game/Multiplayer/MySyncInventory.cs
@@ -525,24 +525,20 @@ namespace Sandbox.Game.Multiplayer
             if (!srcItem.HasValue) return;
 
             FixTransferAmount(src, dst, srcItem, spawn, ref remove, ref amount);
-
-            if (src != dst)
+            if (amount != 0)
             {
-                // If it's not the same source and destination inventory then add the items to the new inventory first and then remove them from the old one
-                if (amount != 0)
-                {
+                if (src != dst)
+                {                                    
                     if (dst.AddItems(amount, srcItem.Value.Content, destItemIndex))
                     {
                         if (remove != 0)
+                        {
                             src.RemoveItems(itemId, remove);
+                        }
                     }
                 }
-            }
-            else
-            {
-                // If it's the same inventory then remove the items first and then add them to the new position.
-                if (amount != 0)
-                {
+                else
+                { 
                     if (remove != 0)
                     {
                         src.RemoveItems(itemId, remove);


### PR DESCRIPTION
Problem: In survival mode, when an item in an inventory is moved to a different slot in
the same inventory, it won't change position when the volume (or mass, but I can't think of anything that restricts that) of the items being moved is greater than the remaining empty volume in the container.

Affects:  All player and block inventories, but particularly noticeable when using refineries, where it becomes difficult to manage the ore input queue, because you can't move items around. 

Cause:  The items were being added to the inventory before being removed
from it, without checking whether it was the same inventory, so the new
volume calculated had the potential to exceed the available space in the
container, even though it had no more items in it than it began with.
The process makes sense when you're moving items from one container to another,
but not to the same one.

Resolution: Added a check to see if the source and destination
inventories are the same and if they are then the items are removed first
and then the items are added into the new position selected, otherwise the original
transfer method is used.

To Reproduce Error:  
1) Start a world in survival mode.
2) Build any block that has an inventory (or use the players inventory)
3) Fill it with an item that uses about 50% of the volume.
4) Add one or more items with about 10% of the container volume.
5) Try to move the first 50% item around, in the same inventory, and you will not be able to.
6) You will be able to move the smaller items around easily.

Bug Report: 
http://forums.keenswh.com/threads/survival-unable-to-move-items-around-in-the-same-inventory.7365376/
