### PR TITLE
FIX: Refinery/Assembler inventories cause all inventories below them to jerk around

### DIFF
--- a/Sources/Sandbox.Game/Game/Screens/Helpers/MyGuiControlInventoryOwner.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Helpers/MyGuiControlInventoryOwner.cs
@@ -240,8 +240,19 @@ namespace Sandbox.Game.Screens.Helpers
             {
                 var inventory = (MyInventory)inventoryGrid.UserData;
                 int itemsCount = inventory.GetItems().Count;
+                int oldRowsCount = inventoryGrid.RowsCount;
+
                 inventoryGrid.ColumnsCount = Math.Max(1, (int)((Size.X - m_internalPadding.X * 2f) / (inventoryGrid.ItemSize.X * 1.01f)));
                 inventoryGrid.RowsCount = Math.Max(1, (int)Math.Ceiling((itemsCount + 1) / (float)inventoryGrid.ColumnsCount));
+
+                if ((itemsCount % inventoryGrid.ColumnsCount) > (inventoryGrid.ColumnsCount - 2))
+                {
+                    if (inventoryGrid.RowsCount < oldRowsCount)
+                    {                       
+                        inventoryGrid.RowsCount++;
+                    }
+                }
+
                 inventoryGrid.TrimEmptyItems();
             }
         }


### PR DESCRIPTION
Problem: 

On the Terminal->Inventory screen, when inventories have 7 items in them, they automatically generate a new line of slots to allow the player to move more items into the inventory later.   

Everything in the inventory panel below that block, will then be shuffled down to make space for the new line.  Once the 7th item is removed the inventory shrinks and everything below it moves up again.

Where refinery output's and assembler input's are present, this can lead to horrible issues when trying to use the inventories below them, as both frequently have very small quantities of an ore or ingots in the 7th item, which is then used up almost immediately, causing the inventory rows to grow and shrink repeatedly and rapidly up to several times a second.

All inventories below that become incredibly hard to use as (particularly with multiple refineries etc.) they jump up and down the screen over large distances almost at random.  

Resolution:

This fixes that problem, by only removing the additional row created once the 6th item, rather than the 7th, has been removed.  A check is made to ensure that if a 7th item has just been removed (inferred by the number of rows present previously as opposed to now) then the newly created inventory slot row will not be removed.

The new slot row will still be freshly generated only when a 7th item has been added (not removed), as before.

So far as I can determine in testing, this works perfectly and provides a stable inventory screen, regardless of the number of refineries, etc. present that are constantly processing their 7th (or a multiple of that value) item.

To recreate the error:

1) Open a new survival world.
2) Create a refinery, an assembler and a cargo crate, in that order.
3) Put 100Kg of 6 types of ingots (including iron, silicon and gold, but NOT platinum) into the refinery output inventory.
4) Put 100 Kg of platinum into the refinery input inventory.
5) Add 100 solar cells to the assembler production queue.
6) Watch the inventory of the assembler and the cargo crate jump up and down like a fruit machine.
7) The effect becomes worse, the more refineries you have in this state.