### PR TITLE
Feature: Terminalpropertyextension string

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Interfaces/ITerminalProperty.cs
+++ b/Sources/Sandbox.Common/ModAPI/Interfaces/ITerminalProperty.cs
@@ -58,6 +58,11 @@ namespace Sandbox.ModAPI.Interfaces
             return property.As<bool>();
         }
 
+        public static ITerminalProperty<string> AsString(this ITerminalProperty property)
+        {
+            return property.As<string>();
+        }
+
         public static float GetValueFloat(this Ingame.IMyTerminalBlock block, string propertyId)
         {
             return block.GetValue<float>(propertyId);
@@ -76,6 +81,16 @@ namespace Sandbox.ModAPI.Interfaces
         public static void SetValueBool(this Ingame.IMyTerminalBlock block, string propertyId, bool value)
         {
             block.SetValue<bool>(propertyId, value);
+        }
+
+        public static string GetValueString(this Ingame.IMyTerminalBlock block, string propertyId)
+        {
+            return block.GetValue<string>(propertyId);
+        }
+
+        public static void SetValueString(this Ingame.IMyTerminalBlock block, string propertyId, string value)
+        {
+            block.SetValue<string>(propertyId, value);
         }
 
         public static void SetValue<T>(this Ingame.IMyTerminalBlock block, string propertyId, T value)

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlLabel.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlLabel.cs
@@ -9,7 +9,7 @@ using VRage.Utils;
 
 namespace Sandbox.Game.Screens.Terminal.Controls
 {
-    public class MyTerminalControlLabel<TBlock> : MyTerminalValueControl<TBlock, bool>       
+    public class MyTerminalControlLabel<TBlock> : MyTerminalValueControl<TBlock, string>       
         where TBlock : MyTerminalBlock
     {
         public readonly MyStringId Label;
@@ -26,30 +26,29 @@ namespace Sandbox.Game.Screens.Terminal.Controls
             return new MyGuiControlBlockProperty(MyTexts.GetString(Label), null, m_label, MyGuiControlBlockPropertyLayoutEnum.Horizontal);
         }
 
-
-
-        public override bool GetValue(TBlock block)
+        public override string GetValue(TBlock block)
         {
-            return true;
+            return MyTexts.GetString(Label);
         }
 
-        public override void SetValue(TBlock block, bool value)
+        // label is readonly
+        public override void SetValue(TBlock block, string value)
         {
         }
 
-        public override bool GetDefaultValue(TBlock block)
+        public override string GetDefaultValue(TBlock block)
         {
-            return false;
+            return "";
         }
 
-        public override bool GetMininum(TBlock block)
+        public override string GetMininum(TBlock block)
         {
-            return false;
+            return "";
         }
 
-        public override bool GetMaximum(TBlock block)
+        public override string GetMaximum(TBlock block)
         {
-            return true;
+            return "";
         }
     }
 }

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlTextbox.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlTextbox.cs
@@ -12,10 +12,12 @@ using VRage.Utils;
 using VRage;
 using VRage.Utils;
 using VRage.Library.Utils;
+using Sandbox.Game.Screens.Terminal.Controls;
+
 
 namespace Sandbox.Game.Gui
 {
-    class MyTerminalControlTextbox<TBlock> : MyTerminalControl<TBlock>
+    class MyTerminalControlTextbox<TBlock> : MyTerminalValueControl<TBlock, string>
         where TBlock : MyTerminalBlock
     {
         public delegate StringBuilder GetterDelegate(TBlock block);
@@ -89,6 +91,39 @@ namespace Sandbox.Game.Gui
                     m_textbox.TextChanged += m_textChanged;
                 }
             }
+        }
+
+
+        public override string GetValue(TBlock block)
+        {
+            return Getter(block).ToString();
+        }
+
+        // label is readonly
+        public override void SetValue(TBlock block, string value)
+        {
+            StringBuilder newText = Getter(block);
+            if (value != newText.ToString())
+            {
+                newText.Clear();
+                newText.Append(value);
+                Setter(block, newText);
+            }
+        }
+
+        public override string GetDefaultValue(TBlock block)
+        {
+            return "";
+        }
+
+        public override string GetMininum(TBlock block)
+        {
+            return "";
+        }
+
+        public override string GetMaximum(TBlock block)
+        {
+            return "";
         }
     }
 }


### PR DESCRIPTION
adds terminaproperty value of string to be retrieved or set
- IMyTerminaBlock.GetValue<string>(block, id) and IMyTerminaBlock<block>.GetValue<string>(id)
- IMyTerminaBlock.GetValue(block, id).AsString() and IMyTerminaBlock<block>.GetValue(id).AsString()
- IMyTerminaBlock.SetValue(block, id, string) and IMyTerminaBlock<block>.SetValue(id, string)
- IMyTerminalPropertyExtension.GetMinValue(), GetMaxValue(), GetDefaultValue() return empty string (eg.have no use on this property)

i'm currently investigating about adding posibility to retrieve maximum length of text for SetValue().

this can be used on textboxes (getvalue/setvalue) or labels (getvalue only)
from what i see there is not much blocks that will benefit from this, but i still plan to have all controls on block available for direct control (including lists and comboxes), to allow same control over block as from gui.

as a "sidefect" this exposes property field "Name" on each block, which equals to IMyTerminalBlock.CustomName

it can be also used to set argument on Programable block, then you can use Run action to apply.