### PR TITLE
Slightly more realistic gravity.

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/MyPlanet.cs
+++ b/Sources/Sandbox.Game/Game/Entities/MyPlanet.cs
@@ -57,7 +57,7 @@ namespace Sandbox.Game.Entities
     public class MyPlanet : MyVoxelBase, IMyGravityProvider, IMyOxygenProvider
     {
         const int PHYSICS_SECTOR_SIZE_METERS = 2048;
-        const float DEFAULT_GRAVITY_RADIUS_KM = 50.0f;
+        //const float DEFAULT_GRAVITY_RADIUS_KM = 50.0f;
         const int ENVIROMENT_EXTEND = 1;
         const int ENVIROMENT_EXTEND_KEEP =  2*ENVIROMENT_EXTEND;
 
@@ -469,17 +469,17 @@ namespace Sandbox.Game.Entities
             {
                 distanceToCenter -= m_planetInitValues.MaximumHillRadius;
                 double distanceToRadius = m_planetInitValues.AveragePlanetRadius / (m_planetInitValues.AveragePlanetRadius + distanceToCenter);
-                attenuation = (float)Math.Pow(distanceToRadius, m_planetInitValues.GravityFalloff);
+                attenuation = (float)Math.Pow(distanceToRadius, 2.0f);
             }
             else if (distanceToCenter < m_planetInitValues.MinimumSurfaceRadius)
             {
                 double distanceToRadius = m_planetInitValues.AveragePlanetRadius / (m_planetInitValues.AveragePlanetRadius + distanceToCenter);
-                attenuation = (float)(1.0- distanceToRadius);
+                attenuation = (float)(1.0 - distanceToRadius) * 2.0f;
             }
 
-            float planetScale = m_planetInitValues.AveragePlanetRadius / (DEFAULT_GRAVITY_RADIUS_KM * 1000.0f);
+            float planetScale = (float)Math.Pow(m_planetInitValues.AveragePlanetRadius, 1.5f) * 2.52982f * (float)Math.Pow(10.0f, -7.0f) ;
             float gravityMultiplier = attenuation * planetScale;
-            return direction * MyGravityProviderSystem.G * (gravityMultiplier >= 0.05f ? gravityMultiplier : 0.0f);
+            return direction * MyGravityProviderSystem.G * (gravityMultiplier >= 0.01f ? gravityMultiplier : 0.0f);
         }
 
         public Vector3 GetWorldGravityNormalized(ref Vector3D worldPoint)
@@ -491,7 +491,7 @@ namespace Sandbox.Game.Entities
 
         public bool IsPositionInRange(Vector3D worldPoint)
         {
-            return (WorldMatrix.Translation - worldPoint).Length() < 2.0f * m_planetInitValues.AveragePlanetRadius;
+            return (WorldMatrix.Translation - worldPoint).Length() < 4.0f * m_planetInitValues.AveragePlanetRadius;
         }
 
         public Vector3 GetWorldGravityGrid(Vector3D worldPoint)


### PR DESCRIPTION
Requesting Newtonian force model to enable fixed elliptical orbits. Updated force function to reflect that.

Fixed a little bug that presented when going underground. Once below the minimum hill radius, the gravity would instantly drop to half.  I simply doubled that attenuation.

Extended the field range to 4x the planet's radius instead of 2x. This makes high altitude orbits optional for low speed space station geeks.

Changed scaling to be slightly exponential. Realistic would be a cubic relationship. Used 1.5 instead. This way, a planet twice the diameter does not only have twice the gravity. Realistically it would have been 8x, but I made a change that makes it ~3.5x instead of 2x.