### PR TITLE
Access to RemoteControl autopilot features (basic)

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyRemoteControl.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyRemoteControl.cs
@@ -2,11 +2,23 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using VRageMath;
 
 namespace Sandbox.ModAPI.Ingame
 {
     public interface IMyRemoteControl : IMyShipController
     {
+        void AddWaypoint(string name, Vector3 coords);
+        void RemoveWaypoint(string name);
 
+
+    }
+
+
+    public enum FlightMode : int
+    {
+        Patrol = 0,
+        Circle = 1,
+        OneWay = 2,
     }
 }

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyRemoteControl.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyRemoteControl.cs
@@ -8,13 +8,40 @@ namespace Sandbox.ModAPI.Ingame
 {
     public interface IMyRemoteControl : IMyShipController
     {
+        /// <summary>
+        /// Adds a waypoint with given name and coords at the end of the waypoints list
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="coords"></param>
         void AddWaypoint(string name, Vector3 coords);
+        
+        /// <summary>
+        /// Removes first waypoint with given name
+        /// </summary>
+        /// <param name="name"></param>
         void RemoveWaypoint(string name);
 
+        /// <summary>
+        /// Changes direction to fly in via code, alternatively use actions available on remote control to do this
+        /// </summary>
+        /// <param name="direction"></param>
+        void ChangeDirection(Base6Directions.Direction direction);
 
+        /// <summary>
+        /// Same function as "Reset" button in UE
+        /// </summary>
+        void ResetWaypoint();
+
+        /// <summary>
+        /// Called "Precision mode" in UI
+        /// </summary>
+        /// <param name="enabled"></param>
+        void SetDockingMode(bool enabled);
     }
-
-
+    
+    /// <summary>
+    /// Flight mode. Moved here from MyRemoteControl.cs because it is required in the interface now
+    /// </summary>
     public enum FlightMode : int
     {
         Patrol = 0,

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyRemoteControl.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyRemoteControl.cs
@@ -41,12 +41,8 @@ namespace Sandbox.Game.Entities
     [MyCubeBlockType(typeof(MyObjectBuilder_RemoteControl))]
     public class MyRemoteControl : MyShipController, IMyPowerConsumer, IMyUsableEntity, IMyRemoteControl
     {
-        public enum FlightMode : int
-        {
-            Patrol = 0,
-            Circle = 1,
-            OneWay = 2,
-        }
+
+        
 
         public class MyAutopilotWaypoint
         {
@@ -699,6 +695,22 @@ namespace Sandbox.Game.Entities
             }
         }
 
+        /// <summary>
+        /// Directly add a waypoint without using GPS locations
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="coords"></param>
+        public void AddWaypoint(string name, Vector3 coords)
+        {
+
+            Vector3D[] coordsArray = new Vector3D[1];
+            string[] names = new string[1];
+
+            names[0] = name;
+            coordsArray[0] = coords;
+            SyncObject.AddWaypoints(coordsArray, names);
+        }
+
         private void OnAddWaypoints(Vector3D[] coords, string[] names)
         {
             Debug.Assert(coords.Length == names.Length);
@@ -839,6 +851,20 @@ namespace Sandbox.Game.Entities
                 SyncObject.RemoveWaypoints(indexes);
 
                 m_selectedWaypoints.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Directly remove waypoints based on name
+        /// </summary>
+        /// <param name="name"></param>
+        public void RemoveWaypoint(string name)
+        {
+            var index = m_waypoints.IndexOf(m_waypoints.FirstOrDefault(x => x.Name == name));
+            if (index != -1)
+            {
+                int[] indexes = {index};
+                SyncObject.RemoveWaypoints(indexes);
             }
         }
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyRemoteControl.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyRemoteControl.cs
@@ -634,7 +634,7 @@ namespace Sandbox.Game.Entities
             }
         }
 
-        private void SetDockingMode(bool enabled)
+        public void SetDockingMode(bool enabled)
         {
             if (enabled != m_dockingModeEnabled)
             {
@@ -902,7 +902,7 @@ namespace Sandbox.Game.Entities
             RaisePropertiesChangedRemote();
         }
 
-        private void ChangeDirection(Base6Directions.Direction direction)
+        public void ChangeDirection(Base6Directions.Direction direction)
         {
             if (direction != m_currentDirection)
             {
@@ -986,7 +986,7 @@ namespace Sandbox.Game.Entities
             return m_selectedWaypoints.Count > 0;
         }
 
-        private void ResetWaypoint()
+        public void ResetWaypoint()
         {
             SyncObject.SendResetWaypoint();
         }


### PR DESCRIPTION
Many people are trying to recreate the auto pilot with own ingame scripting code because it is not possible to access the ingame autopilot on a remote block. I extended the IMyRemoteControl interface with the necessary methods and made those either available (some only needed to be made public) or added them to the MyRemoteControl class.