### PR TITLE
Don't check for moved door entities when grid isn't moving

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyAirtightDoorGeneric.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyAirtightDoorGeneric.cs
@@ -250,7 +250,7 @@ namespace Sandbox.Game.Entities.Blocks
         public override void UpdateAfterSimulation()
         {
             base.UpdateAfterSimulation();
-            if (CubeGrid.Physics == null)
+            if (CubeGrid.Physics == null || !CubeGrid.Physics.IsMoving)
                 return;
             //Update door position because of inaccuracies in high velocities
             UpdateDoorPosition();


### PR DESCRIPTION
`UpdateDoorPosition()` updates the positions of the various sub-entities (door parts) of an Airtight Door, be it a regular door, airtight hanger door, etc. This is called when the block initializes, opens/closes, and after every simulation frame. However it only needs to be called on simulation if moving. 

This PR does not change the current functionality in any way, just removes an unnecessary check when the grid is not moving. I've tested it with doors in game and the still have their position updated just fine.

This function is fairly expensive with a large number of doors. In my 5-week-old survival world we have 113 regular doors and 542 airtight hanger doors. When profiled, `UpdateDoorPosition()` took 5.08% sample time.

![image](https://cloud.githubusercontent.com/assets/1958130/9109992/e7c573fa-3bee-11e5-8da2-8285e34ed821.png)
For comparison to the turret update function (which is only one part of the turrets' expensive updates), we have 116 turrets.

With this change, it doesn't even show up in `MyEntities.UpdateAfterSimulation`'s list.

![image](https://cloud.githubusercontent.com/assets/1958130/9110097/b4efb9c6-3bef-11e5-8fb6-4e463fd4707c.png)

Note all the numbers here a little lower because I spent less time in-game during that test.

**TLDR: Please merge this to improve door performance.**

