### PR TITLE
Fixed 587 "BlinkLenght" typos to "BlinkLength"

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyLightingBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyLightingBlock.cs
@@ -10,7 +10,7 @@ namespace Sandbox.ModAPI.Ingame
         float Radius{ get;}
         float Intensity{get;}
         float BlinkIntervalSeconds{get;}
-        float BlinkLenght{get;}
+        float BlinkLength{get;}
         float BlinkOffset{get;}
     }
 }

--- a/Sources/Sandbox.Game/Definitions/MyLightingBlockDefinition.cs
+++ b/Sources/Sandbox.Game/Definitions/MyLightingBlockDefinition.cs
@@ -16,7 +16,7 @@ namespace Sandbox.Definitions
         public MyBounds LightFalloff;
         public MyBounds LightIntensity;
         public MyBounds BlinkIntervalSeconds;
-        public MyBounds BlinkLenght;
+        public MyBounds BlinkLength;
         public MyBounds BlinkOffset;
         public float RequiredPowerInput;
         public string LightGlare;
@@ -29,7 +29,7 @@ namespace Sandbox.Definitions
             var ob = (MyObjectBuilder_LightingBlockDefinition)builder;
 
             BlinkIntervalSeconds = ob.LightBlinkIntervalSeconds;
-            BlinkLenght = ob.LightBlinkLenght;
+            BlinkLength = ob.LightBlinkLength;
             BlinkOffset = ob.LightBlinkOffset;
             LightRadius        = ob.LightRadius;
             LightFalloff       = ob.LightFalloff;

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyLightingBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyLightingBlock.cs
@@ -54,9 +54,9 @@ namespace Sandbox.Game.Entities.Blocks
         {
             get { return BlockDefinition.BlinkIntervalSeconds; }
         }
-        public MyBounds BlinkLenghtBounds
+        public MyBounds BlinkLengthBounds
         {
-            get { return BlockDefinition.BlinkLenght; }
+            get { return BlockDefinition.BlinkLength; }
         }
         public MyBounds BlinkOffsetBounds
         {
@@ -167,14 +167,14 @@ namespace Sandbox.Game.Entities.Blocks
             lightBlinkTime.EnableActions();
             MyTerminalControlFactory.AddControl(lightBlinkTime);
 
-            var lightBlinkLenght = new MyTerminalControlSlider<MyLightingBlock>("Blink Lenght", MySpaceTexts.BlockPropertyTitle_LightBlinkLenght, MySpaceTexts.BlockPropertyDescription_LightBlinkLenght);
-            lightBlinkLenght.SetLimits((x) => x.BlinkLenghtBounds.Min, (x) => x.BlinkLenghtBounds.Max);
-            lightBlinkLenght.DefaultValueGetter = (x) => x.BlinkLenghtBounds.Default;
-            lightBlinkLenght.Getter = (x) => x.BlinkLength;
-            lightBlinkLenght.Setter = (x, v) => x.SyncObject.SendChangeLightBlinkLengthRequest(v);
-            lightBlinkLenght.Writer = (x, result) => result.Append(MyValueFormatter.GetFormatedFloat(x.BlinkLength, NUM_DECIMALS)).Append(" %");
-            lightBlinkLenght.EnableActions();
-            MyTerminalControlFactory.AddControl(lightBlinkLenght);
+            var lightBlinkLength = new MyTerminalControlSlider<MyLightingBlock>("Blink Lenght", MySpaceTexts.BlockPropertyTitle_LightBlinkLength, MySpaceTexts.BlockPropertyDescription_LightBlinkLength);
+            lightBlinkLength.SetLimits((x) => x.BlinkLengthBounds.Min, (x) => x.BlinkLengthBounds.Max);
+            lightBlinkLength.DefaultValueGetter = (x) => x.BlinkLengthBounds.Default;
+            lightBlinkLength.Getter = (x) => x.BlinkLength;
+            lightBlinkLength.Setter = (x, v) => x.SyncObject.SendChangeLightBlinkLengthRequest(v);
+            lightBlinkLength.Writer = (x, result) => result.Append(MyValueFormatter.GetFormatedFloat(x.BlinkLength, NUM_DECIMALS)).Append(" %");
+            lightBlinkLength.EnableActions();
+            MyTerminalControlFactory.AddControl(lightBlinkLength);
 
             var ligthBlinkOffset = new MyTerminalControlSlider<MyLightingBlock>("Blink Offset", MySpaceTexts.BlockPropertyTitle_LightBlinkOffset, MySpaceTexts.BlockPropertyDescription_LightBlinkOffset);
             ligthBlinkOffset.SetLimits((x) => x.BlinkOffsetBounds.Min, (x) => x.BlinkOffsetBounds.Max);
@@ -317,7 +317,7 @@ namespace Sandbox.Game.Entities.Blocks
 
             m_blinkIntervalSeconds = BlinkIntervalSecondsBounds.Clamp((builder.BlinkIntervalSeconds == -1f) ? BlinkIntervalSecondsBounds.Default : builder.BlinkIntervalSeconds);
 
-            m_blinkLength = BlinkLenghtBounds.Clamp((builder.BlinkLenght == -1f) ? BlinkLenghtBounds.Default : builder.BlinkLenght);
+            m_blinkLength = BlinkLengthBounds.Clamp((builder.BlinkLength == -1f) ? BlinkLengthBounds.Default : builder.BlinkLength);
 
             m_blinkOffset = BlinkOffsetBounds.Clamp((builder.BlinkOffset == -1f) ? BlinkOffsetBounds.Default : builder.BlinkOffset);
 
@@ -365,7 +365,7 @@ namespace Sandbox.Game.Entities.Blocks
             builder.Falloff = m_light.Falloff;
             builder.Intensity = m_intesity;
             builder.BlinkIntervalSeconds = m_blinkIntervalSeconds;
-            builder.BlinkLenght = m_blinkLength;
+            builder.BlinkLength = m_blinkLength;
             builder.BlinkOffset = m_blinkOffset;
             return builder;
         }
@@ -432,9 +432,9 @@ namespace Sandbox.Game.Entities.Blocks
                 ulong elapsedTimeMilisecond = (ulong)(MySession.Static.ElapsedGameTime.TotalMilliseconds - blinkOffsetMiliseconds);
 
                 ulong blinkProgressMilisecond = elapsedTimeMilisecond % blinkIntervalMiliseconds;
-                ulong blinkLenghtMilisecond = (ulong)(blinkIntervalMiliseconds * m_blinkLength * FROM_PERCENT);
+                ulong BlinkLengthMilisecond = (ulong)(blinkIntervalMiliseconds * m_blinkLength * FROM_PERCENT);
 
-                if (blinkLenghtMilisecond > blinkProgressMilisecond)
+                if (BlinkLengthMilisecond > blinkProgressMilisecond)
                 {
                     m_light.ReflectorOn = true;
                     m_light.GlareOn = true;
@@ -532,7 +532,7 @@ namespace Sandbox.Game.Entities.Blocks
         float IMyLightingBlock.Radius { get { return Radius;} }
         float IMyLightingBlock.Intensity { get { return Intensity; } }
         float IMyLightingBlock.BlinkIntervalSeconds { get { return BlinkIntervalSeconds; } }
-        float IMyLightingBlock.BlinkLenght { get { return BlinkLength;} }
+        float IMyLightingBlock.BlinkLength { get { return BlinkLength;} }
         float IMyLightingBlock.BlinkOffset { get {return BlinkOffset;} }
     }
 }

--- a/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
+++ b/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
@@ -6992,7 +6992,7 @@ namespace Sandbox.Game.Localization
         ///<summary>
         ///Length  of blinking as percentage of blink interval
         ///</summary>
-        public static readonly MyStringId BlockPropertyDescription_LightBlinkLenght = MyStringId.GetOrCompute("BlockPropertyDescription_LightBlinkLenght");
+        public static readonly MyStringId BlockPropertyDescription_LightBlinkLength = MyStringId.GetOrCompute("BlockPropertyDescription_LightBlinkLength");
 
         ///<summary>
         ///Offset of blinking as percentage of blink interval
@@ -7007,7 +7007,7 @@ namespace Sandbox.Game.Localization
         ///<summary>
         ///Blink Length
         ///</summary>
-        public static readonly MyStringId BlockPropertyTitle_LightBlinkLenght = MyStringId.GetOrCompute("BlockPropertyTitle_LightBlinkLenght");
+        public static readonly MyStringId BlockPropertyTitle_LightBlinkLength = MyStringId.GetOrCompute("BlockPropertyTitle_LightBlinkLength");
 
         ///<summary>
         ///Blink Offset

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
@@ -4380,7 +4380,7 @@ Reinstalling the game is not enough, because Steam does not delete unknown files
   <data name="BlockPropertyDescription_LightBlinkInterval" xml:space="preserve">
     <value>Blinking interval of light (in seconds)</value>
   </data>
-  <data name="BlockPropertyDescription_LightBlinkLenght" xml:space="preserve">
+  <data name="BlockPropertyDescription_LightBlinkLength" xml:space="preserve">
     <value>Length  of blinking as percentage of blink interval</value>
   </data>
   <data name="BlockPropertyDescription_LightBlinkOffset" xml:space="preserve">
@@ -4389,7 +4389,7 @@ Reinstalling the game is not enough, because Steam does not delete unknown files
   <data name="BlockPropertyTitle_LightBlinkInterval" xml:space="preserve">
     <value>Blink Interval</value>
   </data>
-  <data name="BlockPropertyTitle_LightBlinkLenght" xml:space="preserve">
+  <data name="BlockPropertyTitle_LightBlinkLength" xml:space="preserve">
     <value>Blink Length</value>
   </data>
   <data name="BlockPropertyTitle_LightBlinkOffset" xml:space="preserve">

--- a/Sources/SpaceEngineers/Content/Data/Prefabs/Base4.sbc
+++ b/Sources/SpaceEngineers/Content/Data/Prefabs/Base4.sbc
@@ -1402,7 +1402,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -2640,7 +2640,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -8621,7 +8621,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -21997,7 +21997,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -22015,7 +22015,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -22033,7 +22033,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -22060,7 +22060,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -22078,7 +22078,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -22096,7 +22096,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -22114,7 +22114,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -22132,7 +22132,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -22150,7 +22150,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -22652,7 +22652,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -22678,7 +22678,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -22696,7 +22696,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -22714,7 +22714,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -23776,7 +23776,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -23834,7 +23834,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -23876,7 +23876,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -23974,7 +23974,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -24000,7 +24000,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -24038,7 +24038,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -24056,7 +24056,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -24082,7 +24082,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -24108,7 +24108,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -24829,7 +24829,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -24847,7 +24847,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -24865,7 +24865,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -24883,7 +24883,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -24901,7 +24901,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -24919,7 +24919,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -25027,7 +25027,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -25045,7 +25045,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -25063,7 +25063,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -25081,7 +25081,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -25543,7 +25543,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CargoContainer">
@@ -40291,7 +40291,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -40309,7 +40309,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -40327,7 +40327,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -40345,7 +40345,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CargoContainer">
@@ -40394,7 +40394,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -40412,7 +40412,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -40430,7 +40430,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -40448,7 +40448,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -40466,7 +40466,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -40484,7 +40484,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -40502,7 +40502,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -40520,7 +40520,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -40538,7 +40538,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -40572,7 +40572,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -40590,7 +40590,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -50543,7 +50543,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50561,7 +50561,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50579,7 +50579,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50597,7 +50597,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -50624,7 +50624,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -50650,7 +50650,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -50676,7 +50676,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50694,7 +50694,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_Conveyor">
@@ -50738,7 +50738,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50756,7 +50756,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50774,7 +50774,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50792,7 +50792,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50810,7 +50810,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50828,7 +50828,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50846,7 +50846,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50864,7 +50864,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50882,7 +50882,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50900,7 +50900,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50918,7 +50918,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50936,7 +50936,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50954,7 +50954,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50972,7 +50972,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -50990,7 +50990,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51008,7 +51008,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51026,7 +51026,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51044,7 +51044,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51062,7 +51062,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51080,7 +51080,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51100,7 +51100,7 @@
               <Falloff>1.61458349</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_ButtonPanel">
@@ -51218,7 +51218,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51236,7 +51236,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51254,7 +51254,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51272,7 +51272,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51290,7 +51290,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51308,7 +51308,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51326,7 +51326,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51344,7 +51344,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51362,7 +51362,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51380,7 +51380,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51398,7 +51398,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51416,7 +51416,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51434,7 +51434,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51452,7 +51452,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51470,7 +51470,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51488,7 +51488,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51506,7 +51506,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51524,7 +51524,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -51542,7 +51542,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -53941,7 +53941,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -53959,7 +53959,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -53977,7 +53977,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -54251,7 +54251,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54269,7 +54269,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54287,7 +54287,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54305,7 +54305,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -54363,7 +54363,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54381,7 +54381,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -54417,7 +54417,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -54444,7 +54444,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_ConveyorConnector">
@@ -54471,7 +54471,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54489,7 +54489,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54507,7 +54507,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_ConveyorConnector">
@@ -54534,7 +54534,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54552,7 +54552,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54570,7 +54570,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54588,7 +54588,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54606,7 +54606,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54624,7 +54624,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54642,7 +54642,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54660,7 +54660,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CargoContainer">
@@ -54693,7 +54693,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54711,7 +54711,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -54738,7 +54738,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54756,7 +54756,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54774,7 +54774,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54792,7 +54792,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54810,7 +54810,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -54828,7 +54828,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -55262,7 +55262,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_ConveyorConnector">
@@ -55289,7 +55289,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -55933,7 +55933,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -55951,7 +55951,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -55969,7 +55969,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -55987,7 +55987,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -56005,7 +56005,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -56023,7 +56023,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -57450,7 +57450,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_Passage">

--- a/Sources/SpaceEngineers/Content/Data/Prefabs/BaseEasyStart1.sbc
+++ b/Sources/SpaceEngineers/Content/Data/Prefabs/BaseEasyStart1.sbc
@@ -5187,7 +5187,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -5207,7 +5207,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -5290,7 +5290,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -5318,7 +5318,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -5618,7 +5618,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -5638,7 +5638,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">

--- a/Sources/SpaceEngineers/Content/Data/Prefabs/ConstructionShip.sbc
+++ b/Sources/SpaceEngineers/Content/Data/Prefabs/ConstructionShip.sbc
@@ -1778,7 +1778,7 @@
               <Falloff>1</Falloff>
               <Intensity>4</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_ReflectorLight">
@@ -1796,7 +1796,7 @@
               <Falloff>1</Falloff>
               <Intensity>4</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">

--- a/Sources/SpaceEngineers/Content/Data/Prefabs/Fighter2.sbc
+++ b/Sources/SpaceEngineers/Content/Data/Prefabs/Fighter2.sbc
@@ -2725,7 +2725,7 @@
               <Falloff>1</Falloff>
               <Intensity>4</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">

--- a/Sources/SpaceEngineers/Content/Data/Prefabs/LargeShipBlue.sbc
+++ b/Sources/SpaceEngineers/Content/Data/Prefabs/LargeShipBlue.sbc
@@ -1300,7 +1300,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_AirVent">
@@ -1459,7 +1459,7 @@
               <Falloff>1</Falloff>
               <Intensity>2</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_ReflectorLight">
@@ -1480,7 +1480,7 @@
               <Falloff>1</Falloff>
               <Intensity>2</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_Thrust">
@@ -1562,7 +1562,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -1763,7 +1763,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_OxygenTank">
@@ -1945,7 +1945,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -7734,7 +7734,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -9517,7 +9517,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -10540,7 +10540,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_LandingGear">
@@ -10679,7 +10679,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_AirtightHangarDoor">
@@ -10779,7 +10779,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -10799,7 +10799,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -10819,7 +10819,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -10847,7 +10847,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -10983,7 +10983,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -11740,7 +11740,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -11760,7 +11760,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -11780,7 +11780,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -11808,7 +11808,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_AirtightHangarDoor">
@@ -11908,7 +11908,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_Conveyor">
@@ -12125,7 +12125,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -12145,7 +12145,7 @@
               <Falloff>1.3</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_ConveyorConnector">
@@ -12447,7 +12447,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -12467,7 +12467,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -14304,7 +14304,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -14324,7 +14324,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_TextPanel">
@@ -14388,7 +14388,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_AirtightHangarDoor">
@@ -15095,7 +15095,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15115,7 +15115,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15135,7 +15135,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15155,7 +15155,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15175,7 +15175,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15195,7 +15195,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15215,7 +15215,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15235,7 +15235,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15255,7 +15255,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15275,7 +15275,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15295,7 +15295,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15315,7 +15315,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15335,7 +15335,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15355,7 +15355,7 @@ Open             Close</PublicDescription>
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">

--- a/Sources/SpaceEngineers/Content/Data/Prefabs/LargeShipRedCrashed.sbc
+++ b/Sources/SpaceEngineers/Content/Data/Prefabs/LargeShipRedCrashed.sbc
@@ -5527,7 +5527,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -9742,7 +9742,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -15190,7 +15190,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15210,7 +15210,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15229,7 +15229,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15248,7 +15248,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15267,7 +15267,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_Door">
@@ -15308,7 +15308,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15327,7 +15327,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -15354,7 +15354,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -15381,7 +15381,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15400,7 +15400,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15419,7 +15419,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15438,7 +15438,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15457,7 +15457,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15476,7 +15476,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15495,7 +15495,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15514,7 +15514,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15533,7 +15533,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15552,7 +15552,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15571,7 +15571,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15590,7 +15590,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15609,7 +15609,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -15628,7 +15628,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_ConveyorConnector">
@@ -16443,7 +16443,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -16462,7 +16462,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -16481,7 +16481,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -16500,7 +16500,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -16519,7 +16519,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -16538,7 +16538,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -17451,7 +17451,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_ConveyorConnector">

--- a/Sources/SpaceEngineers/Content/Data/Prefabs/LargeShipRedQS1.sbc
+++ b/Sources/SpaceEngineers/Content/Data/Prefabs/LargeShipRedQS1.sbc
@@ -11334,7 +11334,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -13209,7 +13209,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -13286,7 +13286,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -22093,7 +22093,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -22145,7 +22145,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -22309,7 +22309,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -22361,7 +22361,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -22397,7 +22397,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -22417,7 +22417,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -22437,7 +22437,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -22457,7 +22457,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_Door">
@@ -22711,7 +22711,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -22758,7 +22758,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -23292,7 +23292,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -23716,7 +23716,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -24293,7 +24293,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_Door">
@@ -26312,7 +26312,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -26523,7 +26523,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -26543,7 +26543,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -26579,7 +26579,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_BatteryBlock">
@@ -26634,7 +26634,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -26718,7 +26718,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -26738,7 +26738,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -26766,7 +26766,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -26802,7 +26802,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -26822,7 +26822,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -27060,7 +27060,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -27080,7 +27080,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -27100,7 +27100,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -28005,7 +28005,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -28025,7 +28025,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -29738,7 +29738,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -29758,7 +29758,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -31518,7 +31518,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -31538,7 +31538,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -31558,7 +31558,7 @@
               <Falloff>1</Falloff>
               <Intensity>0.880208731</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -31578,7 +31578,7 @@
               <Falloff>1</Falloff>
               <Intensity>0.880208731</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -31598,7 +31598,7 @@
               <Falloff>1</Falloff>
               <Intensity>0.880208731</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -31626,7 +31626,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -31646,7 +31646,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -31698,7 +31698,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -31718,7 +31718,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -31738,7 +31738,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -31814,7 +31814,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_ButtonPanel">
@@ -32094,7 +32094,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -32114,7 +32114,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -32134,7 +32134,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -32154,7 +32154,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -32174,7 +32174,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -32194,7 +32194,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_ButtonPanel">
@@ -32622,7 +32622,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_InteriorLight">
@@ -32642,7 +32642,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">

--- a/Sources/SpaceEngineers/Content/Data/Prefabs/MinerSmallShip.sbc
+++ b/Sources/SpaceEngineers/Content/Data/Prefabs/MinerSmallShip.sbc
@@ -958,7 +958,7 @@
               <Falloff>1</Falloff>
               <Intensity>4</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
           </CubeBlocks>

--- a/Sources/SpaceEngineers/Content/Data/Prefabs/RespawnShip.sbc
+++ b/Sources/SpaceEngineers/Content/Data/Prefabs/RespawnShip.sbc
@@ -950,7 +950,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">
@@ -1271,7 +1271,7 @@
               <Falloff>1</Falloff>
               <Intensity>1.5</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_ConveyorConnector">

--- a/Sources/SpaceEngineers/Content/Data/Prefabs/SpawnShipDrill.sbc
+++ b/Sources/SpaceEngineers/Content/Data/Prefabs/SpawnShipDrill.sbc
@@ -204,7 +204,7 @@
               <Falloff>1</Falloff>
               <Intensity>4</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_ReflectorLight">
@@ -224,7 +224,7 @@
               <Falloff>1</Falloff>
               <Intensity>4</Intensity>
               <BlinkIntervalSeconds>0</BlinkIntervalSeconds>
-              <BlinkLenght>10</BlinkLenght>
+              <BlinkLength>10</BlinkLength>
               <BlinkOffset>0</BlinkOffset>
             </MyObjectBuilder_CubeBlock>
             <MyObjectBuilder_CubeBlock xsi:type="MyObjectBuilder_CubeBlock">

--- a/Sources/VRage.Game/ObjectBuilders/Definitions/MyObjectBuilder_LightingBlockDefinition.cs
+++ b/Sources/VRage.Game/ObjectBuilders/Definitions/MyObjectBuilder_LightingBlockDefinition.cs
@@ -31,7 +31,7 @@ namespace Sandbox.Common.ObjectBuilders.Definitions
         public SerializableBounds LightBlinkIntervalSeconds = new SerializableBounds(0.0f, 30.0f, 0);
 
         [ProtoMember]
-        public SerializableBounds LightBlinkLenght = new SerializableBounds(0.0f, 100.0f, 10.0f);
+        public SerializableBounds LightBlinkLength = new SerializableBounds(0.0f, 100.0f, 10.0f);
 
         [ProtoMember]
         public SerializableBounds LightBlinkOffset = new SerializableBounds(0.0f, 100.0f, 0);

--- a/Sources/VRage.Game/ObjectBuilders/MyObjectBuilder_LightingBlock.cs
+++ b/Sources/VRage.Game/ObjectBuilders/MyObjectBuilder_LightingBlock.cs
@@ -36,7 +36,7 @@ namespace Sandbox.Common.ObjectBuilders
         public float BlinkIntervalSeconds = -1f;
 
         [ProtoMember, DefaultValue(-1f)]
-        public float BlinkLenght = -1f;
+        public float BlinkLength = -1f;
 
         [ProtoMember, DefaultValue(-1f)]
         public float BlinkOffset = -1f;


### PR DESCRIPTION
I was trying to write a script in game one day and I used set value on "BlinkLength" and I kept getting a null reference exception so I investigated and found that everywhere "BlinkLength" should be it is misspelled as "BlinkLenght". The fields are the only cases where it affects players, but I figured they should all be changed anyways.