### PR TITLE
Added BlockDefinition to IMySlimBlock

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/IMySlimBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/IMySlimBlock.cs
@@ -5,54 +5,35 @@ namespace Sandbox.ModAPI
 {
     public interface IMySlimBlock : Ingame.IMySlimBlock
     {
-        float AccumulatedDamage { get; }
         void AddNeighbours();
         void ApplyAccumulatedDamage(bool addDirtyParts = true);
-        float BuildIntegrity { get; }
-        float BuildLevelRatio { get; }
         string CalculateCurrentModel(out VRageMath.Matrix orientation);
         //bool CanContinueBuild(Sandbox.Game.MyInventory sourceInventory);
         //void ClearConstructionStockpile(Sandbox.Game.MyInventory outputInventory);
         void ComputeScaledCenter(out VRageMath.Vector3D scaledCenter);
         void ComputeScaledHalfExtents(out VRageMath.Vector3 scaledHalfExtents);
         void ComputeWorldCenter(out VRageMath.Vector3D worldCenter);
-        float CurrentDamage { get; }
-        float DamageRatio { get; }
         //void DecreaseMountLevel(float grinderAmount, Sandbox.Game.MyInventory outputInventory);
         //void DoDamage(float damage, Sandbox.Game.Weapons.MyStringHash damageType, bool addDirtyParts = true);
-        IMyCubeBlock FatBlock { get; }
         void FixBones(float oldDamage, float maxAllowedBoneMovement);
         void FullyDismount(IMyInventory outputInventory);
         //int GetConstructionStockpileItemAmount(Sandbox.Definitions.MyDefinitionId id);
         MyObjectBuilder_CubeBlock GetCopyObjectBuilder();
-        void GetMissingComponents(System.Collections.Generic.Dictionary<string, int> addToDictionary);
         MyObjectBuilder_CubeBlock GetObjectBuilder();
-        bool HasDeformation { get; }
         //void IncreaseMountLevel(float welderMountAmount, long welderOwnerPlayerId, Sandbox.Game.MyInventory outputInventory = null, float maxAllowedBoneMovement = 0.0f);
         //void Init(Sandbox.Common.ObjectBuilders.MyObjectBuilder_CubeBlock objectBuilder, Sandbox.Game.Entities.MyCubeGrid cubeGrid, Sandbox.Game.Entities.MyCubeBlock fatBlock);
         void InitOrientation(ref VRageMath.Vector3I forward, ref VRageMath.Vector3I up);
         void InitOrientation(VRageMath.Base6Directions.Direction Forward, VRageMath.Base6Directions.Direction Up);
         void InitOrientation(VRageMath.MyBlockOrientation orientation);
-        bool IsDestroyed { get; }
-        bool IsFullIntegrity { get; }
-        bool IsFullyDismounted { get; }
-        float MaxDeformation { get; }
-        float MaxIntegrity { get; }
-        float Mass { get; }
         //void MoveFirstItemToConstructionStockpile(Sandbox.Game.MyInventory fromInventory);
         void MoveItemsFromConstructionStockpile(IMyInventory toInventory, MyItemFlags flags = MyItemFlags.None);
         //void MoveItemsToConstructionStockpile(Sandbox.Game.MyInventory fromInventory);
         //void PlayConstructionSound(Sandbox.Game.Entities.MyCubeGrid.MyIntegrityChangeEnum integrityChangeType, bool deconstruction = false);
         void RemoveNeighbours();
         void SetToConstructionSite();
-        bool ShowParts { get; }
         void SpawnConstructionStockpile();
         void SpawnFirstItemInConstructionStockpile();
-        bool StockpileAllocated { get; }
-        bool StockpileEmpty { get; }
-        void UpdateVisual();
-        Vector3I Position { get; set; }
-        IMyCubeGrid CubeGrid { get; }
+        new Vector3I Position { get; set; } // overwrite intentional
         VRageMath.Vector3 GetColorMask();
     }
 }

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMySlimBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMySlimBlock.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using VRage.Game;
 using VRageMath;
 namespace Sandbox.ModAPI.Ingame
 {
@@ -30,5 +31,6 @@ namespace Sandbox.ModAPI.Ingame
         void UpdateVisual();
         Vector3I Position { get; }
         IMyCubeGrid CubeGrid { get; }
+        MyDefinitionId BlockDefinition { get; }
     }
 }

--- a/Sources/Sandbox.Game/ModAPI/Blocks/MySlimBlock_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/Blocks/MySlimBlock_ModAPI.cs
@@ -4,24 +4,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using VRage.Game;
+using VRage.ObjectBuilders;
 
 namespace Sandbox.Game.Entities.Cube
 {
     public partial class MySlimBlock : IMySlimBlock
     {
-        IMyCubeBlock IMySlimBlock.FatBlock
+        ModAPI.Ingame.IMyCubeBlock ModAPI.Ingame.IMySlimBlock.FatBlock
         {
             get { return FatBlock; }
-        }
-
-        Sandbox.ModAPI.Ingame.IMyCubeBlock Sandbox.ModAPI.Ingame.IMySlimBlock.FatBlock
-        {
-            get { return FatBlock; }
-        }
-
-        float IMySlimBlock.AccumulatedDamage
-        {
-            get { return AccumulatedDamage; }
         }
 
         void IMySlimBlock.AddNeighbours()
@@ -32,16 +23,6 @@ namespace Sandbox.Game.Entities.Cube
         void IMySlimBlock.ApplyAccumulatedDamage(bool addDirtyParts)
         {
             ApplyAccumulatedDamage(addDirtyParts);
-        }
-
-        float IMySlimBlock.BuildIntegrity
-        {
-            get { return BuildIntegrity; }
-        }
-
-        float IMySlimBlock.BuildLevelRatio
-        {
-            get { return BuildLevelRatio; }
         }
 
         string IMySlimBlock.CalculateCurrentModel(out VRageMath.Matrix orientation)
@@ -64,16 +45,6 @@ namespace Sandbox.Game.Entities.Cube
             ComputeWorldCenter(out worldCenter);
         }
 
-        float IMySlimBlock.CurrentDamage
-        {
-            get { return CurrentDamage; }
-        }
-
-        float IMySlimBlock.DamageRatio
-        {
-            get { return DamageRatio; }
-        }
-
         void IMySlimBlock.FixBones(float oldDamage, float maxAllowedBoneMovement)
         {
             FixBones(oldDamage, maxAllowedBoneMovement);
@@ -89,19 +60,9 @@ namespace Sandbox.Game.Entities.Cube
             return GetCopyObjectBuilder();
         }
 
-        void IMySlimBlock.GetMissingComponents(Dictionary<string, int> addToDictionary)
-        {
-            GetMissingComponents(addToDictionary);
-        }
-
         MyObjectBuilder_CubeBlock IMySlimBlock.GetObjectBuilder()
         {
             return GetObjectBuilder();
-        }
-
-        bool IMySlimBlock.HasDeformation
-        {
-            get { return HasDeformation; }
         }
 
         void IMySlimBlock.InitOrientation(ref VRageMath.Vector3I forward, ref VRageMath.Vector3I up)
@@ -119,35 +80,6 @@ namespace Sandbox.Game.Entities.Cube
             InitOrientation(orientation);
         }
 
-        bool IMySlimBlock.IsDestroyed
-        {
-            get { return IsDestroyed; }
-        }
-
-        bool IMySlimBlock.IsFullIntegrity
-        {
-            get { return IsFullIntegrity; }
-        }
-
-        bool IMySlimBlock.IsFullyDismounted
-        {
-            get { return IsFullyDismounted; }
-        }
-
-        float IMySlimBlock.MaxDeformation
-        {
-            get { return MaxDeformation; }
-        }
-
-        float IMySlimBlock.MaxIntegrity
-        {
-            get { return MaxIntegrity; }
-        }
-
-        float IMySlimBlock.Mass
-        {
-            get { return GetMass();  }
-        }
         void IMySlimBlock.RemoveNeighbours()
         {
             RemoveNeighbours();
@@ -156,11 +88,6 @@ namespace Sandbox.Game.Entities.Cube
         void IMySlimBlock.SetToConstructionSite()
         {
             SetToConstructionSite();
-        }
-
-        bool IMySlimBlock.ShowParts
-        {
-            get { return ShowParts; }
         }
 
         void IMySlimBlock.SpawnConstructionStockpile()
@@ -176,21 +103,6 @@ namespace Sandbox.Game.Entities.Cube
         void IMySlimBlock.SpawnFirstItemInConstructionStockpile()
         {
             SpawnFirstItemInConstructionStockpile();
-        }
-
-        bool IMySlimBlock.StockpileAllocated
-        {
-            get { return StockpileAllocated; }
-        }
-
-        bool IMySlimBlock.StockpileEmpty
-        {
-            get { return StockpileEmpty; }
-        }
-
-        void IMySlimBlock.UpdateVisual()
-        {
-            UpdateVisual();
         }
 
         float ModAPI.Ingame.IMySlimBlock.AccumulatedDamage
@@ -278,7 +190,6 @@ namespace Sandbox.Game.Entities.Cube
             UpdateVisual();
         }
 
-
         VRageMath.Vector3I IMySlimBlock.Position
         {
             get
@@ -291,21 +202,21 @@ namespace Sandbox.Game.Entities.Cube
             }
         }
 
-
         VRageMath.Vector3I ModAPI.Ingame.IMySlimBlock.Position
         {
             get { return Position; }
         }
 
-        Sandbox.ModAPI.Ingame.IMyCubeGrid ModAPI.Ingame.IMySlimBlock.CubeGrid
+        ModAPI.Ingame.IMyCubeGrid ModAPI.Ingame.IMySlimBlock.CubeGrid
         {
             get { return CubeGrid; }
         }
 
-        Sandbox.ModAPI.IMyCubeGrid ModAPI.IMySlimBlock.CubeGrid
+        MyDefinitionId ModAPI.Ingame.IMySlimBlock.BlockDefinition
         {
-            get { return CubeGrid; }
-        }        
+            get { return BlockDefinition.Id; }
+        }
+
         VRageMath.Vector3 IMySlimBlock.GetColorMask()
         {
             return ColorMaskHSV;


### PR DESCRIPTION
Added `BlockDefinition` field for IMySlimBlock for both ingame and modding use, which is really useful to determine what the block actually is when it doesn't have a `FatBlock` available.

Also removed unnecessary fields in the modding interface because they already exist in the ingame one which is implemented by the modding one, therefore the fields are available there regardless.
With the exception of `Position` which is intentionally overwritten to provide the 'set' ability.