### PR TITLE
Bugfix/ilinjector member rewrites

### DIFF
--- a/Sources/VRage.Library/Compiler/IlInjector.cs
+++ b/Sources/VRage.Library/Compiler/IlInjector.cs
@@ -258,14 +258,25 @@ namespace VRage.Compiler
                 
                 var parameters = method.GetParameters();
                 Type[] parameterTypes = new Type[parameters.Length];
-                int i = 0;
-                foreach (var parameter in parameters)
+                for(var i = 0; i < parameters.Length; i++)
                 {
-                    parameterTypes[i++] = MaybeSubstituteType(typeLookup, parameter.ParameterType);
+                    parameterTypes[i] = MaybeSubstituteType(typeLookup, parameters[i].ParameterType);
                 }
                 
                 var definedMethod = newType.DefineMethod(method.Name, method.Attributes, method.CallingConvention, MaybeSubstituteType(typeLookup, method.ReturnType), parameterTypes);
-
+                if(method.IsGenericMethodDefinition)
+                {
+                    var genericArgs = method.GetGenericArguments();
+                    var names = genericArgs.Select(a => a.Name).ToArray();
+                    var definedGenericArgs = definedMethod.DefineGenericParameters(names);
+                    for(var i = 0; i < genericArgs.Length; i++)
+                    {
+                        var a = genericArgs[i];
+                        var d = definedGenericArgs[i];
+                        if(a.BaseType != null && a.BaseType != typeof(object)) d.SetBaseTypeConstraint(a.BaseType);
+                    }
+                }
+                
                 createdMethods.Add(method, definedMethod);
             }
         }

--- a/Sources/VRage.Library/Compiler/IlInjector.cs
+++ b/Sources/VRage.Library/Compiler/IlInjector.cs
@@ -211,6 +211,20 @@ namespace VRage.Compiler
         private static Type MaybeSubstituteType(Dictionary<Type, TypeBuilder> typeLookup, Type type)
         {
             if(type == null) return null;
+            if(type.HasElementType)
+            {
+                var elementType = MaybeSubstituteType(typeLookup, type.GetElementType());
+                if(elementType == type.GetElementType()) return type;
+
+                if(type.IsByRef) return elementType.MakeByRefType();
+                if(type.IsArray) return elementType.MakeArrayType(type.GetArrayRank());
+
+                // We never expect to see this, but completeness...
+                if(type.IsPointer) return elementType.MakePointerType();
+
+                Debug.Fail(String.Format("Type {0} claimed HasElementType but is not a pointer, array, or ByRef.", type));
+            }
+
             if(!type.IsGenericTypeDefinition && type.IsGenericType)
             {
                 var genericArguments = type.GetGenericArguments();


### PR DESCRIPTION
Fixes multiple bugs in IlInjector around type rewriting.
- The _safe injected assembly no longer uses methods and types from the uninjected one.
  - Generic type parameters fixed, ie. List of A
  - Ref and array types fixed
  - Generic method calls fixed, eg. Linq
- Type dependencies are considered when finalising the injected module.
- Performance improvements.
