### PR TITLE
Read only entity from sensor

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyCubeBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyCubeBlock.cs
@@ -19,6 +19,7 @@ namespace Sandbox.ModAPI.Ingame
         string GetOwnerFactionTag();
         Sandbox.Common.MyRelationsBetweenPlayerAndBlock GetPlayerRelationToOwner();
         Sandbox.Common.MyRelationsBetweenPlayerAndBlock GetUserRelationToOwner(long playerId);
+        bool isControllableForProgrammableBlock { get; }
         bool IsBeingHacked { get; }
         bool IsFunctional { get; }
         bool IsWorking { get; }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
@@ -248,6 +248,8 @@ namespace Sandbox.Game.Entities.Blocks
             var gridGroup = MyCubeGridGroups.Static.Logical.GetGroup(CubeGrid);
             var terminalSystem = gridGroup.GroupData.TerminalSystem;
             terminalSystem.UpdateGridBlocksOwnership(this.OwnerId);
+            terminalSystem.updateControllingProgrammingBlock(this.SlimBlock);
+
             m_instance.GridTerminalSystem = terminalSystem;
 
             m_isRunning = true;

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBlock.cs
@@ -114,6 +114,11 @@ namespace Sandbox.Game.Entities
             get { return MySandboxGame.TotalTimeInMilliseconds - HackAttemptTime < MyGridConstants.HACKING_ATTEMPT_TIME_MS; }
         }
 
+        public bool isControllableForProgrammableBlock
+        {
+            get { return CubeGrid.isProgrammaticallyControllable(); }
+        }
+
         public MyCubeBlockDefinition BlockDefinition { get { return SlimBlock.BlockDefinition; } }
         public Vector3I Min { get { return SlimBlock.Min; } }
         public Vector3I Max { get { return SlimBlock.Max; } }

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeGrid.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeGrid.cs
@@ -298,6 +298,14 @@ namespace Sandbox.Game.Entities
             MainCockpit = cockpit;
         }
 
+        // The block that is accessing this MyCubeGrid - usually the currently running programming block
+        public MySlimBlock programmaticallyControllingBlock;
+
+        public bool isProgrammaticallyControllable()
+        {
+            return CubeBlocks.Contains(programmaticallyControllingBlock);
+        }
+
         public MyCubeGrid() :
             this(MyCubeSize.Large)
         {

--- a/Sources/Sandbox.Game/Game/GameSystems/MyGridTerminalSystem.cs
+++ b/Sources/Sandbox.Game/Game/GameSystems/MyGridTerminalSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using System.Linq;
 using System.Collections.Generic;
 using Sandbox.Game.Entities.Cube;
 using VRage.Collections;
@@ -148,6 +149,23 @@ namespace Sandbox.Game.GameSystems
             {
                 block.IsAccessibleForProgrammableBlock = block.HasPlayerAccess(ownerID);
             }
+        }
+
+        // sets the programming block that is accessing the cubeGrid in order to enforce "read-only" access to detected blocks
+        // that are not part of the programming block's cubeGrid
+        public void updateControllingProgrammingBlock(MySlimBlock programmableBlock)
+        {
+            // currently only sensors and landing gears return "detected" blocks
+            // because landing gears have a physical connection to the attached cubegrid they may be considered able to have "write" access.
+
+            // TODO: make cubeGrids returned by landing gears respect block ownership - possibly through the UpdateGridBlocksOwnership() function
+            // alternatively, add any cubeGrids they return to the detectedCubeGrids function
+            IEnumerable<Sandbox.Game.Entities.MyCubeGrid> detectedCubeGrids = Blocks
+                .Where(terminalBlock => (terminalBlock is Sandbox.ModAPI.Ingame.IMySensorBlock) &&
+                    ((Sandbox.ModAPI.Ingame.IMySensorBlock)terminalBlock).LastDetectedEntity is Sandbox.Game.Entities.MyCubeGrid)
+                .Select(sensorBlock => ((Sandbox.ModAPI.Ingame.IMySensorBlock)sensorBlock).LastDetectedEntity as Sandbox.Game.Entities.MyCubeGrid);
+
+            detectedCubeGrids.ForEach(detectedCubeGrid => detectedCubeGrid.programmaticallyControllingBlock = programmableBlock);
         }
     }
 }

--- a/Sources/Sandbox.Game/ModAPI/Blocks/MyFunctionalBlock_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/Blocks/MyFunctionalBlock_ModAPI.cs
@@ -17,5 +17,11 @@ namespace Sandbox.Game.Entities.Cube
             add { EnabledChanged += GetDelegate(value); }
             remove { EnabledChanged -= GetDelegate(value); }
         }
+
+        void Sandbox.ModAPI.Ingame.IMyFunctionalBlock.RequestEnable(bool enable)
+        {
+            if (this.isControllableForProgrammableBlock)
+                RequestEnable(enable);
+        }
     }
 }

--- a/Sources/Sandbox.Game/ModAPI/Blocks/MyTerminalAction_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/Blocks/MyTerminalAction_ModAPI.cs
@@ -10,21 +10,22 @@ namespace Sandbox.Game.Gui
 {
     public partial class MyTerminalAction<TBlock>
     {
+
         void ModAPI.Interfaces.ITerminalAction.Apply(ModAPI.Ingame.IMyCubeBlock block)
         {
-            if (block is TBlock)
+            if (block is TBlock && block.isControllableForProgrammableBlock)
                 Apply(block as MyTerminalBlock);
         }
 
         void ModAPI.Interfaces.ITerminalAction.Apply(ModAPI.Ingame.IMyCubeBlock block, ListReader<TerminalActionParameter> parameters)
         {
-            if (block is TBlock)
+            if (block is TBlock && block.isControllableForProgrammableBlock)
                 Apply(block as MyTerminalBlock, parameters);
         }
 
         void ModAPI.Interfaces.ITerminalAction.WriteValue(ModAPI.Ingame.IMyCubeBlock block, StringBuilder appendTo)
         {
-            if (block is TBlock)
+            if (block is TBlock && block.isControllableForProgrammableBlock)
                 WriteValue(block as MyTerminalBlock, appendTo);
         }
 

--- a/Sources/Sandbox.Game/ModAPI/Blocks/MyTerminalBlock_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/Blocks/MyTerminalBlock_ModAPI.cs
@@ -97,5 +97,17 @@ namespace Sandbox.Game.Entities.Cube
         {
             (MyTerminalControlFactoryHelper.Static as IMyTerminalActionsHelper).GetProperties(this.GetType(), resultList, collect);
         }
+
+        void ModAPI.Ingame.IMyTerminalBlock.SetCustomName(string text)
+        {
+            if (isControllableForProgrammableBlock)
+                SetCustomName(text);
+        }
+
+        void ModAPI.Ingame.IMyTerminalBlock.SetCustomName(StringBuilder text)
+        {
+            if (isControllableForProgrammableBlock)
+                SetCustomName(text);
+        }
     }
 }

--- a/Sources/Sandbox.Game/ModAPI/Blocks/MyTextPanel_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/Blocks/MyTextPanel_ModAPI.cs
@@ -16,27 +16,31 @@ namespace Sandbox.Game.Entities.Blocks
 
         void ModAPI.Ingame.IMyTextPanel.ShowPublicTextOnScreen()
         {
-            SyncObject.SendShowOnScreenChangeRequest((byte)ShowTextOnScreenFlag.PUBLIC);
+            if (isControllableForProgrammableBlock)
+                SyncObject.SendShowOnScreenChangeRequest((byte)ShowTextOnScreenFlag.PUBLIC);
         }
 
         void ModAPI.Ingame.IMyTextPanel.ShowPrivateTextOnScreen()
         {
-            SyncObject.SendShowOnScreenChangeRequest((byte)ShowTextOnScreenFlag.PRIVATE);
+            if (isControllableForProgrammableBlock)
+                SyncObject.SendShowOnScreenChangeRequest((byte)ShowTextOnScreenFlag.PRIVATE);
         }
 
         void ModAPI.Ingame.IMyTextPanel.ShowTextureOnScreen()
         {
-            SyncObject.SendShowOnScreenChangeRequest((byte)ShowTextOnScreenFlag.NONE);
+            if (isControllableForProgrammableBlock)
+                SyncObject.SendShowOnScreenChangeRequest((byte)ShowTextOnScreenFlag.NONE);
         }
 
         void ModAPI.Ingame.IMyTextPanel.SetShowOnScreen(ShowTextOnScreenFlag set)
         {
-            SyncObject.SendShowOnScreenChangeRequest((byte)set);
+            if (isControllableForProgrammableBlock)
+                SyncObject.SendShowOnScreenChangeRequest((byte)set);
         }
 
         bool ModAPI.Ingame.IMyTextPanel.WritePublicTitle(string value, bool append)
         {
-            if (m_isOpen)
+            if (m_isOpen || !isControllableForProgrammableBlock)
             {
                 return false;
             }
@@ -56,7 +60,7 @@ namespace Sandbox.Game.Entities.Blocks
 
         bool ModAPI.Ingame.IMyTextPanel.WritePublicText(string value, bool append)
         {
-            if (m_isOpen)
+            if (m_isOpen || !isControllableForProgrammableBlock)
             {
                 return false;
             }
@@ -76,7 +80,7 @@ namespace Sandbox.Game.Entities.Blocks
 
         bool ModAPI.Ingame.IMyTextPanel.WritePrivateTitle(string value, bool append)
         {
-            if (m_isOpen)
+            if (m_isOpen || !isControllableForProgrammableBlock)
             {
                 return false;
             }
@@ -96,7 +100,7 @@ namespace Sandbox.Game.Entities.Blocks
 
         bool ModAPI.Ingame.IMyTextPanel.WritePrivateText(string value, bool append)
         {
-            if (m_isOpen)
+            if (m_isOpen || !isControllableForProgrammableBlock)
             {
                 return false;
             }
@@ -116,7 +120,7 @@ namespace Sandbox.Game.Entities.Blocks
 
         void ModAPI.Ingame.IMyTextPanel.AddImageToSelection(string id, bool checkExistence)
         {
-            if (id == null)
+            if (id == null || !isControllableForProgrammableBlock)
             {
                 return;
             }
@@ -140,7 +144,7 @@ namespace Sandbox.Game.Entities.Blocks
 
         void ModAPI.Ingame.IMyTextPanel.AddImagesToSelection(List<string> ids, bool checkExistence)
         {
-            if (ids == null)
+            if (ids == null || !isControllableForProgrammableBlock)
             {
                 return;
             }
@@ -180,7 +184,7 @@ namespace Sandbox.Game.Entities.Blocks
 
         void ModAPI.Ingame.IMyTextPanel.RemoveImageFromSelection(string id, bool removeDuplicates)
         {
-            if (id == null)
+            if (id == null || !isControllableForProgrammableBlock)
             {
                 return;
             }
@@ -214,7 +218,7 @@ namespace Sandbox.Game.Entities.Blocks
 
         void ModAPI.Ingame.IMyTextPanel.RemoveImagesFromSelection(List<string> ids, bool removeDuplicates)
         {
-            if (ids == null)
+            if (ids == null || !isControllableForProgrammableBlock)
             {
                 return;
             }
@@ -251,7 +255,7 @@ namespace Sandbox.Game.Entities.Blocks
 
         void ModAPI.Ingame.IMyTextPanel.ClearImagesFromSelection()
         {
-            if (m_selectedTexturesToDraw.Count == 0)
+            if (m_selectedTexturesToDraw.Count == 0 || !isControllableForProgrammableBlock)
             {
                 return;
             }

--- a/global.props
+++ b/global.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <!-- Modify the line below to contain path to SpaceEngineers\Content in Steam directory -->
-    <ContentPath>c:\Program Files (x86)\Steam\SteamApps\common\SpaceEngineers\Content</ContentPath>
+    <ContentPath>C:\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Content</ContentPath>
     <EffectsFromSources>true</EffectsFromSources>
     <DataFromSources>true</DataFromSources>
   </PropertyGroup>

--- a/global.props
+++ b/global.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <!-- Modify the line below to contain path to SpaceEngineers\Content in Steam directory -->
-    <ContentPath>C:\Program Files (x86)\Steam\steamapps\common\SpaceEngineers\Content</ContentPath>
+    <ContentPath>c:\Program Files (x86)\Steam\SteamApps\common\SpaceEngineers\Content</ContentPath>
     <EffectsFromSources>true</EffectsFromSources>
     <DataFromSources>true</DataFromSources>
   </PropertyGroup>


### PR DESCRIPTION
Restricted ingame scripts from modifying or applying actions on blocks detected through the ship's sensor(s). In other words, ingame scripts no longer have full control over any ship detected by sensors.  
An example of an ingame script that takes control of a detected ship is at http://steamcommunity.com/sharedfiles/filedetails/?id=404907524

This is my first pull request, and I'm still very new to the codebase, so if anyone can see a better way to do this, then I'm all ears.