### PR TITLE
Feature/Set battery stored power through mods

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/IMyBatteryBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/IMyBatteryBlock.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sandbox.ModAPI
+{
+    public interface IMyBatteryBlock : IMyFunctionalBlock, Ingame.IMyPowerProducer, Ingame.IMyBatteryBlock
+    {
+        void SetCurrentStoredPower(float newPower);
+    }
+}

--- a/Sources/Sandbox.Common/Sandbox.Common.csproj
+++ b/Sources/Sandbox.Common/Sandbox.Common.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Components\MyIngameScript.cs" />
     <Compile Include="Components\MySessionComponentBase.cs" />
     <Compile Include="Components\MySessionComponentMapping.cs" />
+    <Compile Include="ModAPI\IMyBatteryBlock.cs" />
     <Compile Include="ModAPI\IMyCamera.cs" />
     <Compile Include="ModAPI\IMyConfig.cs" />
     <Compile Include="ModAPI\IMyDamageSystem.cs" />

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyBatteryBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyBatteryBlock.cs
@@ -38,7 +38,7 @@ namespace Sandbox.Game.Entities
     using VRage.ModAPI;
 
     [MyCubeBlockType(typeof(MyObjectBuilder_BatteryBlock))]
-    class MyBatteryBlock : MyFunctionalBlock, IMyPowerProducer, IMyPowerConsumer, Sandbox.ModAPI.Ingame.IMyBatteryBlock
+    class MyBatteryBlock : MyFunctionalBlock, IMyPowerProducer, IMyPowerConsumer, Sandbox.ModAPI.IMyBatteryBlock
     {
         static string[] m_emissiveNames = new string[] { "Emissive0", "Emissive1", "Emissive2", "Emissive3" };
         private MyBatteryBlockDefinition m_batteryBlockDefinition;
@@ -407,6 +407,18 @@ namespace Sandbox.Game.Entities
                 }
                 m_prevEmissiveColor = color;
                 m_prevFillCount = fillCount;
+            }
+        }
+
+        public void SetCurrentStoredPower(float newPower)
+        {
+            if (newPower > 0)
+            {
+                m_currentStoredPower = newPower < m_maxStoredPower ? newPower : m_maxStoredPower;
+            }
+            else
+            {
+                m_currentStoredPower = 0;
             }
         }
 


### PR DESCRIPTION
This feature allows modders to set a battery's current stored power through script mods via IMyBatteryBlock.SetCurrentStoredPower(float newPower). It will not allow the charge to be set less than 0 and will cap at the battery's maximum capacity. It adds an IMyBatteryBlock interface in Sandbox.Common.ModAPI while keeping the original interface in Sandbox.Common.ModAPI.Ingame.

If anyone's interested, I did this to enable Darth Biomech's Mass Driver mod that I'm programming to use a charge mechanic. This change would also be useful for shield mods now that the damage system is accessible, as well as survival-mode infinite power sources.