### PR TITLE
Bugfix/zipfile access optimisation

### DIFF
--- a/Sources/Sandbox.Game/Definitions/MyDefinitionManager.cs
+++ b/Sources/Sandbox.Game/Definitions/MyDefinitionManager.cs
@@ -2907,7 +2907,7 @@ namespace Sandbox.Definitions
 
                     string modedContentFile = Path.Combine(context.ModPath, contentFile);
 
-                    if (MyFileSystem.DirectoryExists(Path.GetDirectoryName(modedContentFile)) && MyFileSystem.GetFiles(Path.GetDirectoryName(modedContentFile), Path.GetFileName(modedContentFile), VRage.FileSystem.MySearchOption.TopDirectoryOnly).Count() > 0)
+                    if (MyFileSystem.FileExists(modedContentFile))
                     {
                         field.SetValue(fieldOwnerInstance, modedContentFile);
                         //MySandboxGame.Log.WriteLine(string.Format("ProcessField() '{0}', '{1}', '{2}'", context.ModPath, contentFile, modedContentFile));

--- a/Sources/Sandbox.Game/Definitions/MyDefinitionManager.cs
+++ b/Sources/Sandbox.Game/Definitions/MyDefinitionManager.cs
@@ -136,61 +136,64 @@ namespace Sandbox.Definitions
         {
             MySandboxGame.Log.WriteLine("MyDefinitionManager.LoadData() - START");
 
-            UnloadData();
-            LoadScenarios();
-
-            using (MySandboxGame.Log.IndentUsing(LoggingOptions.NONE))
+            using(MyFileSystem.EnableZipCaching())
             {
-                //Load base definitions
-                if(!m_modDefinitionSets.ContainsKey(""))
-                    m_modDefinitionSets.Add("", new DefinitionSet());
-                var baseDefinitionSet = m_modDefinitionSets[""];
-                LoadDefinitions(MyModContext.BaseGame, baseDefinitionSet);
-
-                MySandboxGame.Log.WriteLine(string.Format("List of used mods ({0}) - START", mods.Count));
-                MySandboxGame.Log.IncreaseIndent();
-                foreach (var mod in mods)
-                    MySandboxGame.Log.WriteLine(string.Format("Id = {0}, Filename = '{1}', Name = '{2}'", mod.PublishedFileId, mod.Name, mod.FriendlyName));
-                MySandboxGame.Log.DecreaseIndent();
-                MySandboxGame.Log.WriteLine("List of used mods - END");
-
-                foreach (var mod in mods)
+                UnloadData();
+                LoadScenarios();
+            
+                using (MySandboxGame.Log.IndentUsing(LoggingOptions.NONE))
                 {
-                    MyModContext context = new MyModContext();
-                    context.Init(mod);
+                    //Load base definitions
+                    if(!m_modDefinitionSets.ContainsKey(""))
+                        m_modDefinitionSets.Add("", new DefinitionSet());
+                    var baseDefinitionSet = m_modDefinitionSets[""];
+                    LoadDefinitions(MyModContext.BaseGame, baseDefinitionSet);
 
-                    if (!m_modDefinitionSets.ContainsKey(context.ModPath))
+                    MySandboxGame.Log.WriteLine(string.Format("List of used mods ({0}) - START", mods.Count));
+                    MySandboxGame.Log.IncreaseIndent();
+                    foreach (var mod in mods)
+                        MySandboxGame.Log.WriteLine(string.Format("Id = {0}, Filename = '{1}', Name = '{2}'", mod.PublishedFileId, mod.Name, mod.FriendlyName));
+                    MySandboxGame.Log.DecreaseIndent();
+                    MySandboxGame.Log.WriteLine("List of used mods - END");
+
+                    foreach (var mod in mods)
                     {
-                        var definitionSet = new DefinitionSet();
-                        m_modDefinitionSets.Add(context.ModPath, definitionSet);
-                        LoadDefinitions(context, definitionSet);
-                    }
-                }
+                        MyModContext context = new MyModContext();
+                        context.Init(mod);
 
-                if (MySandboxGame.Static != null)
-                {
-                    LoadPostProcess();
-                }
+                        if (!m_modDefinitionSets.ContainsKey(context.ModPath))
+                        {
+                            var definitionSet = new DefinitionSet();
+                            m_modDefinitionSets.Add(context.ModPath, definitionSet);
+                            LoadDefinitions(context, definitionSet);
+                        }
+                    }
+
+                    if (MySandboxGame.Static != null)
+                    {
+                        LoadPostProcess();
+                    }
                 
-                if (MyFakes.TEST_MODELS)
-                {
-                    var s = Stopwatch.GetTimestamp();
-                    TestCubeBlockModels();
-                    var delta = (Stopwatch.GetTimestamp() - s) / (double)Stopwatch.Frequency;
-                    Debug.WriteLine(String.Format("Models tested in: {0} seconds", delta));
-                }
-
-                var classes = MyDefinitionManager.Static.GetEnvironmentItemClassDefinitions();
-                foreach (var cl in classes)
-                {
-                    List<MyDefinitionId> classList = null;
-                    if (!m_definitions.m_channelEnvironmentItemsDefs.TryGetValue(cl.Channel, out classList))
+                    if (MyFakes.TEST_MODELS)
                     {
-                        classList = new List<MyDefinitionId>();
-                        m_definitions.m_channelEnvironmentItemsDefs[cl.Channel] = classList;
+                        var s = Stopwatch.GetTimestamp();
+                        TestCubeBlockModels();
+                        var delta = (Stopwatch.GetTimestamp() - s) / (double)Stopwatch.Frequency;
+                        Debug.WriteLine(String.Format("Models tested in: {0} seconds", delta));
                     }
 
-                    classList.Add(cl.Id);
+                    var classes = MyDefinitionManager.Static.GetEnvironmentItemClassDefinitions();
+                    foreach (var cl in classes)
+                    {
+                        List<MyDefinitionId> classList = null;
+                        if (!m_definitions.m_channelEnvironmentItemsDefs.TryGetValue(cl.Channel, out classList))
+                        {
+                            classList = new List<MyDefinitionId>();
+                            m_definitions.m_channelEnvironmentItemsDefs[cl.Channel] = classList;
+                        }
+
+                        classList.Add(cl.Id);
+                    }
                 }
             }
             MySandboxGame.Log.WriteLine("MyDefinitionManager.LoadData() - END");

--- a/Sources/VRage.Library/Compression/MyZipArchiveIndex.cs
+++ b/Sources/VRage.Library/Compression/MyZipArchiveIndex.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace VRage.Compression
+{
+    public class MyZipArchiveIndex
+    {
+        private Dictionary<string, string> m_mixedCaseHelper = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+
+        public string ZipPath { get; private set; }
+
+        public MyZipArchiveIndex(string zipPath, IEnumerable<MyZipFileInfo> files)
+        {
+            ZipPath = zipPath;
+            foreach(var file in files)
+            {
+                var name = file.Name;
+                FixName(ref name);
+                m_mixedCaseHelper[name] = file.Name;
+            }
+        }
+
+        private static void FixName(ref string name)
+        {
+            name = name.Replace('/', '\\');
+        }
+
+        public string GetOriginalName(string name)
+        {
+            FixName(ref name);
+            return m_mixedCaseHelper[name];
+        }
+
+        public bool FileExists(string name)
+        {
+            FixName(ref name);
+            return m_mixedCaseHelper.ContainsKey(name);
+        }
+
+        public IEnumerable<string> FileNames
+        {
+            get { return m_mixedCaseHelper.Values.OrderBy(p => p); }
+        }
+
+        public bool DirectoryExists(string name)
+        {
+            FixName(ref name);
+            foreach (var fileName in m_mixedCaseHelper.Keys)
+            {
+                if (fileName.StartsWith(name, StringComparison.InvariantCultureIgnoreCase))
+                    return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Sources/VRage.Library/Filesystem/MyFileSystem.cs
+++ b/Sources/VRage.Library/Filesystem/MyFileSystem.cs
@@ -24,10 +24,12 @@ namespace VRage.FileSystem
         public static string SavesPath { get { CheckUserSpecificInitialized(); return m_savesPath; } }
 
         public static IFileVerifier FileVerifier = new MyNullVerifier();
+
+        static MyZipFileProvider m_zipFileProvider = new MyZipFileProvider();
         static MyFileProviderAggregator m_fileProvider = new MyFileProviderAggregator
             (
                 new MyClassicFileProvider(),
-                new MyZipFileProvider()
+                m_zipFileProvider
             );
 
         private static void CheckInitialized()
@@ -141,6 +143,11 @@ namespace VRage.FileSystem
         public static IEnumerable<string> GetFiles(string path, string filter = "*", VRage.FileSystem.MySearchOption searchOption = VRage.FileSystem.MySearchOption.AllDirectories)
         {
             return m_fileProvider.GetFiles(path, filter, searchOption);
+        }
+
+        public static IDisposable EnableZipCaching()
+        {
+            return m_zipFileProvider.EnableCaching();
         }
     }
 }

--- a/Sources/VRage.Library/VRage.Library.csproj
+++ b/Sources/VRage.Library/VRage.Library.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Compiler\IlInjector.cs" />
     <Compile Include="Compiler\TestScriptHelpers.cs" />
     <Compile Include="Compression\MyZipArchive.cs" />
+    <Compile Include="Compression\MyZipArchiveIndex.cs" />
     <Compile Include="Compression\MyZipArchiveReflection.cs" />
     <Compile Include="Compression\MyZipFileInfo.cs" />
     <Compile Include="Cryptography\MySHA256.cs" />


### PR DESCRIPTION
Cache zipfile indexes during world load to reduce I/O thrash.

The zip format is optimised for writing and appending rather than reading. Loading the archive's index is an expensive operation and should be avoided whenever possible.

By caching zip index information during world load, it is possible to eliminate a large number of filesystem operations which take time which is quadratic (possibly even cubic) in the quantity of mod data. The practical upshot of this optimisation is to reduce half-hour load times for heavily-modded games to just a few minutes.
