### PR TITLE
Display quantity in inventory tooltip

### DIFF
--- a/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
+++ b/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
@@ -3365,7 +3365,7 @@ namespace Sandbox.Game.Localization
         public static readonly MyStringId ScreenTerminalInventory_Volume = MyStringId.GetOrCompute("ScreenTerminalInventory_Volume");
 
         ///<summary>
-        ///{0}{3} Mass: {1} kg Volume: {2} L
+        ///{0}{4} Quantity: {1} Mass: {2} kg Volume: {3} L
         ///</summary>
         public static readonly MyStringId ToolTipTerminalInventory_ItemInfo = MyStringId.GetOrCompute("ToolTipTerminalInventory_ItemInfo");
 

--- a/Sources/Sandbox.Game/Game/Screens/Helpers/MyGuiControlInventoryOwner.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Helpers/MyGuiControlInventoryOwner.cs
@@ -406,14 +406,16 @@ namespace Sandbox.Game.Screens.Helpers
         {
             var definition = MyDefinitionManager.Static.GetPhysicalItemDefinition(item.Content);
 
-            var itemMass = definition.Mass * (double)item.Amount;
-            var itemVolume = definition.Volume * 1000 * (double)item.Amount;
+            double amount = (double)item.Amount;
+            var itemMass = definition.Mass * amount;
+            var itemVolume = definition.Volume * 1000 * amount;
 
             var gridItem = new MyGuiControlGrid.Item(
                 icon: definition.Icon,
                 userData: item,
                 toolTip: new StringBuilder().AppendFormat(MyTexts.GetString(MySpaceTexts.ToolTipTerminalInventory_ItemInfo),
                     definition.DisplayNameText,
+                    (amount < 0.01) ? "<0.01" : amount.ToString(MyInventoryConstants.GUI_DISPLAY_FORMAT, CultureInfo.InvariantCulture),
                     (itemMass < 0.01) ? "<0.01" : itemMass.ToString(MyInventoryConstants.GUI_DISPLAY_FORMAT, CultureInfo.InvariantCulture),
                     (itemVolume < 0.01) ? "<0.01" : itemVolume.ToString(MyInventoryConstants.GUI_DISPLAY_FORMAT, CultureInfo.InvariantCulture),
                     (item.Content.Flags == MyItemFlags.Damaged ? MyTexts.Get(MySpaceTexts.ItemDamagedDescription) : MyTexts.Get(MySpaceTexts.Blank))).ToString());

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.fi.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.fi.resx
@@ -2159,9 +2159,10 @@ Huomaa, että julkaisemalla tämän kohteen hyväksyt workshopin palveluehdot (k
     <value>Tilavuus: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Massa: {1} kg
-Tilavuus: {2} L</value>
+    <value>{0}{4}
+Määrä: {1}
+Massa: {2} kg
+Tilavuus: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Symmetrian X taso: {0} aseta, {1} poista</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.fr.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.fr.resx
@@ -2156,9 +2156,10 @@ Notez qu'en soumettant celui-ci, vous acceptez les termes et conditions du Works
     <value>Volume : {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Masse : {1} kg
-Volume : {2} L</value>
+    <value>{0}{4}
+Quantité : {1}
+Masse : {2} kg
+Volume : {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Plan de symétrie X: {0} pour installer, {1} pour retirer</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.hr-HR.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.hr-HR.resx
@@ -2165,9 +2165,10 @@ Imajte na umu kako objavljujući ovo, pristajene na uvjete i pravila workshopa (
     <value>Volumen: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Masa: {1} kg
-Volumen: {2} L</value>
+    <value>{0}{4}
+Količina: {1}
+Masa: {2} kg
+Volumen: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>центрировать X плоскость:{0} установить, {1} сбросить</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.hu-HU.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.hu-HU.resx
@@ -2161,9 +2161,10 @@ Ezzel automatikusan elfogadod a workshop felhasználási feltételeit (lásd: ht
     <value>Térfogat: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Tömeg: {1} kg
-Térfogat: {2} L</value>
+    <value>{0}{4}
+Mennyiség: {1}
+Tömeg: {2} kg
+Térfogat: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>X tengely szimmetria: {0} elfogad, {1} visszavon</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.is-IS.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.is-IS.resx
@@ -2160,9 +2160,10 @@ Mundu að þú samþykkir skilmála Steam Workshop ( http://steamcommunity.com/s
     <value>Stærð: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Massi: {1} kg
-Stærð: {2} L</value>
+    <value>{0}{4}
+Magn: {1}
+Massi: {2} kg
+Stærð: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Speglun X hlið: {0} til að setja, {1} til að endursetja</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.it.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.it.resx
@@ -2159,9 +2159,10 @@ Nota che caricando questo oggetto, accetti i termini di servizio del workshop (c
     <value>Volume: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Massa: {1} kg
-Volume: {2} L</value>
+    <value>{0}{4}
+Quantità: {1}
+Massa: {2} kg
+Volume: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Simmetria sul piano X: {0} per impostare, {1} per reimpostare</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.lv.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.lv.resx
@@ -2162,9 +2162,10 @@ Note that by submitting this item, you agree to the workshop terms of service (s
     <value>Apjoms: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Masa: {1} Kg
-Tilpums: {2} L</value>
+    <value>{0}{4}
+Daudzums: {1}
+Masa: {2} Kg
+Tilpums: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Simetrija pēc X plaknes: {0}, lai ieviestu, {1}, lai noņemtu</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.nl.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.nl.resx
@@ -2151,9 +2151,10 @@ Als het spel niet vloeiend verloopt, verlaag dan uw schermresolutie.</value>
     <value>Volume: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Massa: {1} kg
-Volume: {2} L</value>
+    <value>{0}{4}
+Hoeveelheid: {1}
+Massa: {2} kg
+Volume: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Symmetrie X vlak: {0} om te setten {1} om te resetten</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.no.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.no.resx
@@ -2157,9 +2157,10 @@ Noter deg at ved å publisere dette, så aksepterer du vilkårene for tjenesten 
     <value>Volum: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3} 
-Masse: {1} kg 
-Volum: {2} L</value>
+    <value>{0}{4} 
+Antall: {1}
+Masse: {2} kg 
+Volum: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Symmetri X plan: {0} for å angi, {1} for å resette</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.pl-PL.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.pl-PL.resx
@@ -2157,9 +2157,10 @@ Jeśli się zgadzasz to równocześnie akceptujesz warunki warsztatu (zobacz htt
     <value>Pojemność: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3} 
-Masa: {1} kg 
-Pojemność: {2} L</value>
+    <value>{0}{4} 
+Ilość: {1}
+Masa: {2} kg 
+Pojemność: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Symetria względem osi X: {0} aby ustawić, {1} aby zresetować</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.pt-BR.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.pt-BR.resx
@@ -2156,9 +2156,10 @@ Note que ao enviar este item, você concorda com os termos de serviço da oficin
     <value>Volume: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3} 
-Massa: {1} kg 
-Volume: {2} L</value>
+    <value>{0}{4} 
+Quantidade: {1}
+Massa: {2} kg 
+Volume: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Simetria plano X: {0} para definir, {1} para redefinir</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
@@ -2162,9 +2162,10 @@ Note that by submitting this item, you agree to the workshop terms of service (s
     <value>Volume: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Mass: {1} kg
-Volume: {2} L</value>
+    <value>{0}{4}
+Quantity: {1}
+Mass: {2} kg
+Volume: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Symmetry X plane: {0} to set, {1} to reset</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.ro.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.ro.resx
@@ -2158,9 +2158,10 @@ Publicând acest mod sunteți de acord cu termenii de serviciu al atelierului (v
     <value>Volum: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Masă: {1} kg
-Volum: {2} L</value>
+    <value>{0}{4}
+Cantitate: {1}
+Masă: {2} kg
+Volum: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Simetrie pe plan X: {0} pentru a seta. {1} pentru a reseta</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.ru.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.ru.resx
@@ -2157,9 +2157,10 @@
     <value>Объем: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Масса: {1} кг
-Объём: {2} л</value>
+    <value>{0}{4}
+количество: {1}
+Масса: {2} кг
+Объём: {3} л</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Центрирование X плоскости: {0} установить, {1} обнулить</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.sk-SK.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.sk-SK.resx
@@ -2158,9 +2158,10 @@ Note that by submitting this item, you agree to the workshop terms of service (s
     <value>Objem: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Hmotnosť: {1} kg
-Objem: {2} L</value>
+    <value>{0}{4}
+Množstvo: {1}
+Hmotnosť: {2} kg
+Objem: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Plocha symetrie X: {0} nastav, {1} reset</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.sv.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.sv.resx
@@ -2159,9 +2159,10 @@ Notera att när du publicerar världen så går du med på tjänstens villkor ( 
     <value>Volym: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Massa: {1} kg
-Volym: {2} L</value>
+    <value>{0}{4}
+Kvantitet: {1}
+Massa: {2} kg
+Volym: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Symmetri på X planet: {0} för att sätta, {1} för att återställa</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.tr-TR.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.tr-TR.resx
@@ -2156,9 +2156,10 @@ Bunu paylaşarak atöyle hizmet şartlarını kabul etmiş sayılırsınız. (g�
     <value>Hacim: {0} L</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Ağırlık: {1} kg
-Hacim: {2} L</value>
+    <value>{0}{4}
+Nicelik: {1}
+Ağırlık: {2} kg
+Hacim: {3} L</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Simetri X düzlemi: Ayarlamak için {0}, sıfırlamak için {1}</value>

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.uk.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.uk.resx
@@ -2154,9 +2154,10 @@
     <value>Об'єм: {0} л</value>
   </data>
   <data name="ToolTipTerminalInventory_ItemInfo" xml:space="preserve">
-    <value>{0}{3}
-Маса: {1} кґ
-Об'єм: {2} л</value>
+    <value>{0}{4}
+кількість: {1}
+Маса: {2} кґ
+Об'єм: {3} л</value>
   </data>
   <data name="SettingSymmetryX" xml:space="preserve">
     <value>Симетрія осі Х: {0}, аби встановити, {1}, щоб скинути</value>


### PR DESCRIPTION
Feature
Added quantity to inventory item tooltip. Useful for large quantities of items measured by a discrete quantity(ex components).

Translation of "Quantity" for the various MyTexts should be double checked.