### PR TITLE
Npcs can perform a Jump on a Jump Drive.

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
@@ -1,11 +1,36 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using VRageMath;
 
 namespace Sandbox.ModAPI.Ingame
 {
     public interface IMyJumpDrive : IMyFunctionalBlock
     {
+        bool CanJump { get; }
+
+        bool IsFull { get; }
+
+        /// <summary>
+        /// Sets the jump distance ratio. Values passed in are clamped to a range between 0 and 100.
+        /// </summary>
+        float JumpDistanceRatio { get; set; }
+
+        bool Recharging { get; set; }
+
+
+
+        double ComputeMaxDistance();
+
+        bool CanJumpAndHasAccess(long userId);
+
+        void RemoveSelected();
+
+        /// <summary>
+        /// Manually sets the target jump point
+        /// </summary>
+        /// <param name="cords">The cordinates to jump to.</param>
+        /// <param name="name">The name of the GPS point to display in the GUI.</param>
+        /// <exception cref="ArgumentNullException">The parameter <see cref="name"/> was null.</exception>
+        void SetTarget(Vector3D cords, string name);
+
     }
 }

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
@@ -81,5 +81,10 @@ namespace Sandbox.ModAPI.Ingame
         /// <exception cref="ArgumentNullException">The parameter <see cref="name"/> was null.</exception>
         void SetTarget(Vector3D cords, string name);
 
+        /// <summary>
+        /// Performs a jump, can only be done my NPC factions.
+        /// </summary>
+        /// <returns>If the jump request was successful.</returns>
+        bool PerformJump();
     }
 }

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
@@ -5,8 +5,14 @@ namespace Sandbox.ModAPI.Ingame
 {
     public interface IMyJumpDrive : IMyFunctionalBlock
     {
+        /// <summary>
+        /// Is the jumpdrive in a state that would allow a jump.
+        /// </summary>
         bool CanJump { get; }
 
+        /// <summary>
+        /// Is the jumpdrive full of energy.
+        /// </summary>
         bool IsFull { get; }
 
         /// <summary>
@@ -14,18 +20,42 @@ namespace Sandbox.ModAPI.Ingame
         /// </summary>
         float JumpDistanceRatio { get; set; }
 
+        /// <summary>
+        /// The amount of power tht needs to be stored to perform a jump in Megawats.
+        /// </summary>
+        float PowerNeededForJump { get; }
+         
+        /// <summary>
+        /// The amount of power stored in the jumpdrive in Megawats.
+        /// </summary>
+        float StoredPower { get; }
+
+        /// <summary>
+        /// The number of seconds remaining in the recharge time.
+        /// </summary>
+        float RechargeTimeRemaining { get; }
+
+        /// <summary>
+        /// Should the jump drive draw power to recharge itself.
+        /// </summary>
         bool Recharging { get; set; }
 
 
-
+        /// <summary>
+        /// Returns the maximum distance in meeters that the jumpdrive will jump with the current settings.
+        /// </summary>
         double ComputeMaxDistance();
 
+        /// <summary>
+        /// Returns if the drive is ready to jump and could be jumped by the specified user.
+        /// </summary>
+        /// <param name="userId">The userId to check against.</param>
         bool CanJumpAndHasAccess(long userId);
 
         void RemoveSelected();
 
         /// <summary>
-        /// Manually sets the target jump point
+        /// Manually sets the target jump point.
         /// </summary>
         /// <param name="cords">The cordinates to jump to.</param>
         /// <param name="name">The name of the GPS point to display in the GUI.</param>

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
@@ -21,12 +21,12 @@ namespace Sandbox.ModAPI.Ingame
         float JumpDistanceRatio { get; set; }
 
         /// <summary>
-        /// The amount of power tht needs to be stored to perform a jump in Megawats.
+        /// The amount of power that needs to be stored to perform a jump in Megawatts.
         /// </summary>
         float PowerNeededForJump { get; }
-         
+
         /// <summary>
-        /// The amount of power stored in the jumpdrive in Megawats.
+        /// The amount of power stored in the jumpdrive in Megawatts.
         /// </summary>
         float StoredPower { get; }
 
@@ -42,7 +42,7 @@ namespace Sandbox.ModAPI.Ingame
 
 
         /// <summary>
-        /// Returns the maximum distance in meeters that the jumpdrive will jump with the current settings.
+        /// Returns the maximum distance in meters that the jumpdrive will jump with the current settings.
         /// </summary>
         double ComputeMaxDistance();
 
@@ -57,7 +57,7 @@ namespace Sandbox.ModAPI.Ingame
         /// <summary>
         /// Manually sets the target jump point.
         /// </summary>
-        /// <param name="cords">The cordinates to jump to.</param>
+        /// <param name="cords">The coordinates to jump to.</param>
         /// <param name="name">The name of the GPS point to display in the GUI.</param>
         /// <exception cref="ArgumentNullException">The parameter <see cref="name"/> was null.</exception>
         void SetTarget(Vector3D cords, string name);

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
@@ -82,9 +82,10 @@ namespace Sandbox.ModAPI.Ingame
         void SetTarget(Vector3D cords, string name);
 
         /// <summary>
-        /// Performs a jump, can only be done my NPC factions.
+        /// Gets the destination coordinates that the jump drive is set to. If set to a Bind Jump the ship controller is used to determine orientation.
         /// </summary>
-        /// <returns>If the jump request was successful.</returns>
-        bool PerformJump();
+        /// <param name="shipController"></param>
+        /// <returns></returns>
+        Vector3D GetJumpCoords(IMyShipController shipController);
     }
 }

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
@@ -16,9 +16,15 @@ namespace Sandbox.ModAPI.Ingame
         bool IsFull { get; }
 
         /// <summary>
-        /// Sets the jump distance ratio. Values passed in are clamped to a range between 0 and 100.
+        /// Gets the jump distance ratio.
         /// </summary>
-        float JumpDistanceRatio { get; set; }
+        float JumpDistanceRatio { get; }
+
+        /// <summary>
+        /// Attempts to set the <see cref="JumpDistanceRatio"/>. Values passed in are clamped to a range between 0 and 100.
+        /// </summary>
+        /// <param name="ratio">The new value to set.</param>
+        void RequestJumpDistanceRatio(float ratio);
 
         /// <summary>
         /// The amount of power that needs to be stored to perform a jump in Megawatts.
@@ -38,11 +44,16 @@ namespace Sandbox.ModAPI.Ingame
         /// <summary>
         /// Should the jump drive draw power to recharge itself.
         /// </summary>
-        bool Recharging { get; set; }
-
+        bool Recharging { get; }
 
         /// <summary>
-        /// Returns the maximum distance in meters that the jumpdrive will jump with the current settings.
+        /// Tries to change the value of <see cref="Recharging"/>.
+        /// </summary>
+        /// <param name="enabled">The new value to set.</param>
+        void RequestRecharging(bool enabled);
+
+        /// <summary>
+        /// Returns the maximum distance in meters that the jumpdrive will jump with the current <see cref="JumpDistanceRatio"/>.
         /// </summary>
         double ComputeMaxDistance();
 
@@ -52,6 +63,9 @@ namespace Sandbox.ModAPI.Ingame
         /// <param name="userId">The userId to check against.</param>
         bool CanJumpAndHasAccess(long userId);
 
+        /// <summary>
+        /// Deselects the jump waypoint if one was set.
+        /// </summary>
         void RemoveSelected();
 
         /// <summary>

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
@@ -16,6 +16,11 @@ namespace Sandbox.ModAPI.Ingame
         bool IsFull { get; }
 
         /// <summary>
+        /// Is the jumpdrive currently performing a jump.
+        /// </summary>
+        bool IsJumping { get; }
+
+        /// <summary>
         /// Gets the jump distance ratio.
         /// </summary>
         float JumpDistanceRatio { get; }

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyRemoteControl.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyRemoteControl.cs
@@ -14,6 +14,14 @@ namespace Sandbox.ModAPI.Ingame
 
         void ClearWaypoints();
         void AddWaypoint(Vector3D point, string name);
+        
+        /// <summary>
+        /// Requests a jump, can only be done my NPC factions.
+        /// </summary>
+        /// <param name="jumpDrive">Jumpdrive to use.</param>
+        /// <returns>If the jump request was successful.</returns>
+        bool RequestJump(IMyJumpDrive jumpDrive);
+        
         void SetAutoPilotEnabled(bool enabled);
 
         // CH: TODO: Uncomment later for drones

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyJumpDrive.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyJumpDrive.cs
@@ -836,11 +836,12 @@ namespace Sandbox.Game.Entities
         public float JumpDistanceRatio
         {
             get { return m_jumpDistanceRatio; }
-            set
-            {
-                var clampedValue = VRageMath.MathHelper.Clamp(value, 0f, 100f);
-                SetJumpDistanceRatio(clampedValue);
-            }
+        }
+
+        public void RequestJumpDistanceRatio(float ratio)
+        {
+            var clampedValue = VRageMath.MathHelper.Clamp(ratio, 0f, 100f);
+            SetJumpDistanceRatio(clampedValue);
         }
 
         public float PowerNeededForJump
@@ -861,7 +862,11 @@ namespace Sandbox.Game.Entities
         public bool Recharging
         {
             get { return m_isRecharging; }
-            set { SetRecharging(value); }
+        }
+
+        public void RequestRecharging(bool enabled)
+        {
+            SetRecharging(enabled);
         }
 
         public void SetTarget(Vector3D cords, string name)

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyJumpDrive.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyJumpDrive.cs
@@ -669,13 +669,18 @@ namespace Sandbox.Game.Entities
                 public BoolBlit Recharging;
             }
 
+            [ProtoBuf.ProtoContract]
             [MessageIdAttribute(8406, P2PMessageEnum.Reliable)]
             protected struct SetTargetMsg : IEntityMessage
             {
+                [ProtoBuf.ProtoMember]
                 public long EntityId;
                 public long GetEntityId() { return EntityId; }
 
+                [ProtoBuf.ProtoMember]
                 public Vector3D Coords;
+
+                [ProtoBuf.ProtoMember]
                 public string Name;
             }
 

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyJumpDrive.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyJumpDrive.cs
@@ -843,6 +843,21 @@ namespace Sandbox.Game.Entities
             }
         }
 
+        public float PowerNeededForJump
+        {
+            get { return BlockDefinition.PowerNeededForJump; }
+        }
+
+        public float StoredPower
+        {
+            get { return m_storedPower; }
+        }
+
+        public float RechargeTimeRemaining
+        {
+            get { return m_timeRemaining; }
+        }
+
         public bool Recharging
         {
             get { return m_isRecharging; }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyJumpDrive.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyJumpDrive.cs
@@ -833,6 +833,11 @@ namespace Sandbox.Game.Entities
 
         #region Programmatic Control
 
+        bool IMyJumpDrive.IsJumping
+        {
+            get { return IsJumping; }
+        }
+
         public float JumpDistanceRatio
         {
             get { return m_jumpDistanceRatio; }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyJumpDrive.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyJumpDrive.cs
@@ -897,6 +897,14 @@ namespace Sandbox.Game.Entities
             RaisePropertiesChangedJumpDrive();
         }
 
+        bool IMyJumpDrive.PerformJump()
+        {
+            if (!MySession.Static.Players.IdentityIsNpc(this.OwnerId))
+                return false;
+
+            throw new NotImplementedException();
+        }
+
         #endregion
     }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyRemoteControl.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyRemoteControl.cs
@@ -2326,6 +2326,19 @@ namespace Sandbox.Game.Entities
             return null;
         }
 
+        bool IMyRemoteControl.RequestJump(IMyJumpDrive jumpDrive)
+        {
+            if (!MySession.Static.Players.IdentityIsNpc(this.OwnerId))
+                return false;
+
+            if (jumpDrive == null || !jumpDrive.CanJump)
+                return false;
+
+            var jumpCoords = jumpDrive.GetJumpCoords(this);
+
+            return CubeGrid.GridSystems.JumpSystem.RequestJumpWithoutPrompt(jumpCoords, this.OwnerId);
+        }
+
         [PreloadRequired]
         public class MySyncRemoteControl : MySyncShipController
         {

--- a/Sources/Sandbox.Game/Game/GameSystems/MyGridJumpDriveSystem.cs
+++ b/Sources/Sandbox.Game/Game/GameSystems/MyGridJumpDriveSystem.cs
@@ -206,7 +206,7 @@ namespace Sandbox.Game.GameSystems
             }
         }
 
-        public void RequestJump(string destinationName, Vector3D destination, long userId)
+        public bool RequestJumpWithoutPrompt(Vector3D destination, long userId)
         {
             if (!Vector3.IsZero(MyGravityProviderSystem.CalculateNaturalGravityInPoint(m_grid.WorldMatrix.Translation)))
             {
@@ -223,22 +223,35 @@ namespace Sandbox.Game.GameSystems
 
             if (!IsJumpValid(userId))
             {
+                return false;
+            }
+
+            double jumpDistance;
+            double actualDistance;
+            bool canPerformJump = RequestJumpCalculation(destination, userId, out jumpDistance, out actualDistance);
+            if (canPerformJump)
+            {
+                SyncObject.RequestJump(m_selectedDestination, userId);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public void RequestJump(string destinationName, Vector3D destination, long userId)
+        {
+            if (!IsJumpValid(userId))
+            {
                 return;
             }
 
-            m_selectedDestination = destination;
-            double maxJumpDistance = GetMaxJumpDistance(userId);
-            m_jumpDirection = destination - m_grid.WorldMatrix.Translation;
-            double jumpDistance = m_jumpDirection.Length();
-            double actualDistance = jumpDistance;
-            if (jumpDistance > maxJumpDistance)
-            {
-                double ratio = maxJumpDistance / jumpDistance;
-                actualDistance = maxJumpDistance;
-                m_jumpDirection *= ratio;
-            }
+            double jumpDistance;
+            double actualDistance;
+            bool canPerformJump = RequestJumpCalculation(destination, userId, out jumpDistance, out actualDistance);
 
-            if (actualDistance < MIN_JUMP_DISTANCE)
+            if (!canPerformJump)
             {
                 MyGuiSandbox.AddScreen(MyGuiSandbox.CreateMessageBox(
                     buttonType: MyMessageBoxButtonsType.OK,
@@ -264,6 +277,30 @@ namespace Sandbox.Game.GameSystems
                     ));
             }
 
+        }
+
+        private bool RequestJumpCalculation(Vector3D destination, long userId, out double jumpDistance, out double actualDistance)
+        {
+            m_selectedDestination = destination;
+            double maxJumpDistance = GetMaxJumpDistance(userId);
+            m_jumpDirection = destination - m_grid.WorldMatrix.Translation;
+            jumpDistance = m_jumpDirection.Length();
+            actualDistance = jumpDistance;
+            if (jumpDistance > maxJumpDistance)
+            {
+                double ratio = maxJumpDistance/jumpDistance;
+                actualDistance = maxJumpDistance;
+                m_jumpDirection *= ratio;
+            }
+
+            if (actualDistance < MIN_JUMP_DISTANCE)
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
         }
 
         private StringBuilder GetConfimationText(string name, double distance, double actualDistance, long userId)


### PR DESCRIPTION
This PR is a superset of the changes in PR #419.

This adds a `RequestJump(IMyJumpDrive jumpDrive)` to `IMyRemoteControl` in similar fashion to `GetNearestPlayer(`. This method will only succeed if called from a remote control block that is owned by a NPC.

It also adds `GetJumpCoords(IMyShipController shipController)` to `IMyJumpDrive` to find the target location of the jump, it uses the `shipController` to determine direction of a bind jump. 

This PR will likely need to be updated once the changes to `MyRemoteControl` which are live but not here on the repository, but I wanted to put this out there now in case people wanted to comment on it.