### PR TITLE
NPC jumpable drives

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyJumpDrive.cs
@@ -2,10 +2,93 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using VRageMath;
 
 namespace Sandbox.ModAPI.Ingame
 {
     public interface IMyJumpDrive : IMyFunctionalBlock
     {
+        /// <summary>
+        /// Is the jumpdrive in a state that would allow a jump.
+        /// </summary>
+        bool CanJump { get; }
+
+        /// <summary>
+        /// Is the jumpdrive full of energy.
+        /// </summary>
+        bool IsFull { get; }
+
+        /// <summary>
+        /// Is the jumpdrive currently performing a jump.
+        /// </summary>
+        bool IsJumping { get; }
+
+        /// <summary>
+        /// Gets the jump distance ratio.
+        /// </summary>
+        float JumpDistanceRatio { get; }
+
+        /// <summary>
+        /// Attempts to set the <see cref="JumpDistanceRatio"/>. Values passed in are clamped to a range between 0 and 100.
+        /// </summary>
+        /// <param name="ratio">The new value to set.</param>
+        void RequestJumpDistanceRatio(float ratio);
+
+        /// <summary>
+        /// The amount of power that needs to be stored to perform a jump in Megawatts.
+        /// </summary>
+        float PowerNeededForJump { get; }
+
+        /// <summary>
+        /// The amount of power stored in the jumpdrive in Megawatts.
+        /// </summary>
+        float StoredPower { get; }
+
+        /// <summary>
+        /// The number of seconds remaining in the recharge time.
+        /// </summary>
+        float RechargeTimeRemaining { get; }
+
+        /// <summary>
+        /// Should the jump drive draw power to recharge itself.
+        /// </summary>
+        bool Recharging { get; }
+
+        /// <summary>
+        /// Tries to change the value of <see cref="Recharging"/>.
+        /// </summary>
+        /// <param name="enabled">The new value to set.</param>
+        void RequestRecharging(bool enabled);
+
+        /// <summary>
+        /// Returns the maximum distance in meters that the jumpdrive will jump with the current <see cref="JumpDistanceRatio"/>.
+        /// </summary>
+        double ComputeMaxDistance();
+
+        /// <summary>
+        /// Returns if the drive is ready to jump and could be jumped by the specified user.
+        /// </summary>
+        /// <param name="userId">The userId to check against.</param>
+        bool CanJumpAndHasAccess(long userId);
+
+        /// <summary>
+        /// Deselects the jump waypoint if one was set.
+        /// </summary>
+        void RemoveSelected();
+
+        /// <summary>
+        /// Manually sets the target jump point.
+        /// </summary>
+        /// <param name="cords">The coordinates to jump to.</param>
+        /// <param name="name">The name of the GPS point to display in the GUI.</param>
+        /// <exception cref="ArgumentNullException">The parameter <see cref="name"/> was null.</exception>
+        void SetTarget(Vector3D cords, string name);
+
+        /// <summary>
+        /// Gets the destination coordinates that the jump drive is set to. If set to a Bind Jump the ship controller is used to determine orientation.
+        /// </summary>
+        /// <param name="shipController"></param>
+        /// <returns></returns>
+        Vector3D GetJumpCoords(IMyShipController shipController);
     }
 }

--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyRemoteControl.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyRemoteControl.cs
@@ -14,6 +14,14 @@ namespace Sandbox.ModAPI.Ingame
 
         void ClearWaypoints();
         void AddWaypoint(Vector3D point, string name);
+        
+        /// <summary>
+        /// Requests a jump, can only be done my NPC factions.
+        /// </summary>
+        /// <param name="jumpDrive">Jumpdrive to use.</param>
+        /// <returns>If the jump request was successful.</returns>
+        bool RequestJump(IMyJumpDrive jumpDrive);
+        
         void SetAutoPilotEnabled(bool enabled);
 
         // CH: TODO: Uncomment later for drones

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyRemoteControl.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyRemoteControl.cs
@@ -2326,6 +2326,19 @@ namespace Sandbox.Game.Entities
             return null;
         }
 
+        bool IMyRemoteControl.RequestJump(IMyJumpDrive jumpDrive)
+        {
+            if (!MySession.Static.Players.IdentityIsNpc(this.OwnerId))
+                return false;
+
+            if (jumpDrive == null || !jumpDrive.CanJump)
+                return false;
+
+            var jumpCoords = jumpDrive.GetJumpCoords(this);
+
+            return CubeGrid.GridSystems.JumpSystem.RequestJumpWithoutPrompt(jumpCoords, this.OwnerId);
+        }
+
         [PreloadRequired]
         public class MySyncRemoteControl : MySyncShipController
         {

--- a/Sources/Sandbox.Game/Game/GameSystems/MyGridJumpDriveSystem.cs
+++ b/Sources/Sandbox.Game/Game/GameSystems/MyGridJumpDriveSystem.cs
@@ -210,15 +210,11 @@ namespace Sandbox.Game.GameSystems
         {
             if (!Vector3.IsZero(MyGravityProviderSystem.CalculateNaturalGravityInPoint(m_grid.WorldMatrix.Translation)))
             {
-                var notification = new MyHudNotification(MySpaceTexts.NotificationCannotJumpFromGravity, 1500);
-                MyHud.Notifications.Add(notification);
-                return;
+                return false;
             }
             if (!Vector3.IsZero(MyGravityProviderSystem.CalculateNaturalGravityInPoint(destination)))
             {
-                var notification = new MyHudNotification(MySpaceTexts.NotificationCannotJumpIntoGravity, 1500);
-                MyHud.Notifications.Add(notification);
-                return;
+                return false;
             }
 
             if (!IsJumpValid(userId))
@@ -242,6 +238,19 @@ namespace Sandbox.Game.GameSystems
 
         public void RequestJump(string destinationName, Vector3D destination, long userId)
         {
+            if (!Vector3.IsZero(MyGravityProviderSystem.CalculateNaturalGravityInPoint(m_grid.WorldMatrix.Translation)))
+            {
+                var notification = new MyHudNotification(MySpaceTexts.NotificationCannotJumpFromGravity, 1500);
+                MyHud.Notifications.Add(notification);
+                return;
+            }
+            if (!Vector3.IsZero(MyGravityProviderSystem.CalculateNaturalGravityInPoint(destination)))
+            {
+                var notification = new MyHudNotification(MySpaceTexts.NotificationCannotJumpIntoGravity, 1500);
+                MyHud.Notifications.Add(notification);
+                return;
+            }
+
             if (!IsJumpValid(userId))
             {
                 return;

--- a/Sources/Sandbox.Game/Game/GameSystems/MyGridJumpDriveSystem.cs
+++ b/Sources/Sandbox.Game/Game/GameSystems/MyGridJumpDriveSystem.cs
@@ -206,7 +206,7 @@ namespace Sandbox.Game.GameSystems
             }
         }
 
-        public void RequestJump(string destinationName, Vector3D destination, long userId)
+        public bool RequestJumpWithoutPrompt(Vector3D destination, long userId)
         {
             if (!Vector3.IsZero(MyGravityProviderSystem.CalculateNaturalGravityInPoint(m_grid.WorldMatrix.Translation)))
             {
@@ -223,22 +223,35 @@ namespace Sandbox.Game.GameSystems
 
             if (!IsJumpValid(userId))
             {
+                return false;
+            }
+
+            double jumpDistance;
+            double actualDistance;
+            bool canPerformJump = RequestJumpCalculation(destination, userId, out jumpDistance, out actualDistance);
+            if (canPerformJump)
+            {
+                SyncObject.RequestJump(m_selectedDestination, userId);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public void RequestJump(string destinationName, Vector3D destination, long userId)
+        {
+            if (!IsJumpValid(userId))
+            {
                 return;
             }
 
-            m_selectedDestination = destination;
-            double maxJumpDistance = GetMaxJumpDistance(userId);
-            m_jumpDirection = destination - m_grid.WorldMatrix.Translation;
-            double jumpDistance = m_jumpDirection.Length();
-            double actualDistance = jumpDistance;
-            if (jumpDistance > maxJumpDistance)
-            {
-                double ratio = maxJumpDistance / jumpDistance;
-                actualDistance = maxJumpDistance;
-                m_jumpDirection *= ratio;
-            }
+            double jumpDistance;
+            double actualDistance;
+            bool canPerformJump = RequestJumpCalculation(destination, userId, out jumpDistance, out actualDistance);
 
-            if (actualDistance < MIN_JUMP_DISTANCE)
+            if (!canPerformJump)
             {
                 MyGuiSandbox.AddScreen(MyGuiSandbox.CreateMessageBox(
                     buttonType: MyMessageBoxButtonsType.OK,
@@ -264,6 +277,30 @@ namespace Sandbox.Game.GameSystems
                     ));
             }
 
+        }
+
+        private bool RequestJumpCalculation(Vector3D destination, long userId, out double jumpDistance, out double actualDistance)
+        {
+            m_selectedDestination = destination;
+            double maxJumpDistance = GetMaxJumpDistance(userId);
+            m_jumpDirection = destination - m_grid.WorldMatrix.Translation;
+            jumpDistance = m_jumpDirection.Length();
+            actualDistance = jumpDistance;
+            if (jumpDistance > maxJumpDistance)
+            {
+                double ratio = maxJumpDistance/jumpDistance;
+                actualDistance = maxJumpDistance;
+                m_jumpDirection *= ratio;
+            }
+
+            if (actualDistance < MIN_JUMP_DISTANCE)
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
         }
 
         private StringBuilder GetConfimationText(string name, double distance, double actualDistance, long userId)


### PR DESCRIPTION
This request gives remote control blocks the ability to initiate a jump. This function can only be called by remote control blocks owned by NPC's, the same way GetNearestPlayer can only be called by a NPC.

This pull request depends on changes made in #425

MyGridJumpDriveSystem changes:
- Refactored logic out of RequestJump( into RequestJumpCalculation(.
- Added RequestJumpWithoutPrompt( which tries to perform a jump request and returns a boolean if the request was sucessful or not.

IMyRemoteControl and MyRemoteControl changes:
- Added RequestJump( which tries to initiate a jump sequence, this method can only be called remote control blocks owned by NPCs.