### PR TITLE
[FIX-LOW] Allow larger scale explosions

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeGrid.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeGrid.cs
@@ -5693,7 +5693,7 @@ namespace Sandbox.Game.Entities
             var localSphere2 = new BoundingSphereD(center, sphere2.Radius);
             var localSphere3 = new BoundingSphereD(center, sphere3.Radius);
 
-            int cellsToCheck = (endIt.X - startIt.X) * (endIt.Y - startIt.Y) * (endIt.Z - startIt.Z);
+            Int64 cellsToCheck = (Int64)(endIt.X - startIt.X) * (Int64)(endIt.Y - startIt.Y) * (Int64)(endIt.Z - startIt.Z);
             if (cellsToCheck < m_cubes.Count)
             {
                 for (int i = startIt.X; i <= endIt.X; i++)

--- a/Sources/Sandbox.Game/Game/ParticleEffects/MyExplosionDamage.cs
+++ b/Sources/Sandbox.Game/Game/ParticleEffects/MyExplosionDamage.cs
@@ -67,7 +67,7 @@ namespace Sandbox.Game
         }
 
         int stackOverflowGuard;
-        const int MAX_PHYSICS_RECURSION_COUNT = 10;
+        const int MAX_PHYSICS_RECURSION_COUNT = 100;
 
         public MyExplosionDamage(HashSet<MySlimBlock> blocksInRadius, BoundingSphereD explosion, float explosionDamage)
         {


### PR DESCRIPTION
Bugfix, Low priority - *(Cannot be exploit in vanilla.)*

The original code generate an integer overflow if the volume result is over 1290^3 causing the value to be negative and the program taking the wrong path that freeze the game for several minutes or hours, the patch will expand this limit to 1,664M ^ 3 ( This should obliterate the entire universe xD ).

Additionally, this patch increases the physics raycast recursion count limit (from 10 to 100) in case the huge explosion ray cross several levels of layers in grids. This was only tested with an explosion as big as an asteroid on the platform base so i'm not 100% sure if the value 100 is big enough for colossal planetary explosions (Death Star superlaser, anyone?).