### PR TITLE
Added GraphicsRenderer field for IMyConfig

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/IMyConfig.cs
+++ b/Sources/Sandbox.Common/ModAPI/IMyConfig.cs
@@ -2,6 +2,7 @@
 using VRage;
 using VRage.Serialization;
 using VRageRender;
+using VRage.Utils;
 
 namespace Sandbox.ModAPI
 {
@@ -32,6 +33,7 @@ namespace Sandbox.ModAPI
         int RefreshRate { get; }
         bool RenderInterpolation { get; }
         MyRenderQualityEnum? RenderQuality { get; }
+        MyGraphicsRenderer GraphicsRenderer { get; }
         bool RotationHints { get; }
         int? ScreenHeight { get; }
         int? ScreenWidth { get; }

--- a/Sources/Sandbox.Game/Engine/Utils/MyConfig.cs
+++ b/Sources/Sandbox.Game/Engine/Utils/MyConfig.cs
@@ -930,6 +930,22 @@ namespace Sandbox.Engine.Utils
             get { return Dx9RenderQuality; }
         }
 
+        MyGraphicsRenderer ModAPI.IMyConfig.GraphicsRenderer
+        {
+            get
+            {
+                var renderer = GraphicsRenderer;
+                if(renderer.HasValue)
+                {
+                    if (renderer.Value == MyStringId.GetOrCompute("DirectX 11"))
+                        return MyGraphicsRenderer.DX11;
+                    else if(renderer.Value == MyStringId.GetOrCompute("DirectX 9"))
+                        return MyGraphicsRenderer.DX9;
+                }
+                return MyGraphicsRenderer.NULL;
+            }
+        }
+
         bool ModAPI.IMyConfig.RotationHints
         {
             get { return RotationHints; }

--- a/Sources/Sandbox.Game/Engine/Utils/MyConfig.cs
+++ b/Sources/Sandbox.Game/Engine/Utils/MyConfig.cs
@@ -942,7 +942,7 @@ namespace Sandbox.Engine.Utils
                     else if(renderer.Value == MyStringId.GetOrCompute("DirectX 9"))
                         return MyGraphicsRenderer.DX9;
                 }
-                return MyGraphicsRenderer.NULL;
+                return MyGraphicsRenderer.NONE;
             }
         }
 

--- a/Sources/VRage/Render/MyRenderEnums.cs
+++ b/Sources/VRage/Render/MyRenderEnums.cs
@@ -128,7 +128,7 @@ namespace VRageRender
 
     public enum MyGraphicsRenderer
     {
-        NULL,
+        NONE,
         DX9,
         DX11
     }

--- a/Sources/VRage/Render/MyRenderEnums.cs
+++ b/Sources/VRage/Render/MyRenderEnums.cs
@@ -126,6 +126,13 @@ namespace VRageRender
         LOW = 3
     }
 
+    public enum MyGraphicsRenderer
+    {
+        NULL,
+        DX9,
+        DX11
+    }
+
     public enum MyRenderModuleEnum
     {
         Cockpit,


### PR DESCRIPTION
This populates the graphics renderer (DX9, DX11 or NONE) read-only through *MyAPIGateway.Session.Config.GraphicsRenderer*.

Right now it's impossible for a script to know what renderer the client is using.