### PR TITLE
Assembler Fix

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyAssembler.cs
@@ -662,9 +662,9 @@ namespace Sandbox.Game.Entities.Cube
                 return;
             }
 
-            if (!ResourceSink.IsPowered || ResourceSink.CurrentInput < ProductionBlockDefinition.OperationalPowerConsumption)
+            if (!ResourceSink.IsPowered || ResourceSink.CurrentInput < GetOperationalPowerConsumption())
             {
-                if (!ResourceSink.IsPowerAvailable(MyResourceDistributorComponent.ElectricityId, ProductionBlockDefinition.OperationalPowerConsumption))
+                if (!ResourceSink.IsPowerAvailable(MyResourceDistributorComponent.ElectricityId, GetOperationalPowerConsumption()))
                 {
                     CurrentState = StateEnum.NotEnoughPower;
                     return;


### PR DESCRIPTION
Assemblers checked if they had 540 kW of power, not if they have enough power to run taking the energy efficiency modules into account.

I'm not sure if you want to use the GetOperationalPowerConsumption method you have in MyAssembler or run the check somewhere else, but this should fix the bug reported in this thread:

http://forum.keenswh.com/threads/01-097-008-not-enough-power-assembler.7366828/

For my work I have to stick with VS2012 (And I don't want to install another version next to it), so I can't build Space Engineers, therefor this is not tested.
