### PR TITLE
New Turret Type for Modding - Large Generic Turret

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyLargeGenericTurret.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyLargeGenericTurret.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Sandbox.ModAPI.Ingame
+{
+    public interface IMyLargeGenericTurret : IMyLargeConveyorTurretBase
+    {
+    }
+}

--- a/Sources/Sandbox.Common/Sandbox.Common.csproj
+++ b/Sources/Sandbox.Common/Sandbox.Common.csproj
@@ -69,6 +69,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\x86\Release Official\Sandbox.Common.XML</DocumentationFile>
     <NoWarn>1591,1572,1571,1573,1587,1570</NoWarn>
+    <UseVSHostingProcess>true</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -161,6 +162,7 @@
     <Compile Include="ModAPI\IMyVoxelShapeRamp.cs" />
     <Compile Include="ModAPI\IMyVoxelShapeSphere.cs" />
     <Compile Include="ModAPI\Ingame\IMyAirVent.cs" />
+    <Compile Include="ModAPI\Ingame\IMyLargeGenericTurret.cs" />
     <Compile Include="ModAPI\Ingame\IMyRadioAntenna.cs" />
     <Compile Include="ModAPI\Ingame\IMyAssembler.cs" />
     <Compile Include="ModAPI\Ingame\IMyBatteryBlock.cs" />

--- a/Sources/Sandbox.Game/Engine/Utils/MyFakes.cs
+++ b/Sources/Sandbox.Game/Engine/Utils/MyFakes.cs
@@ -78,6 +78,7 @@ namespace Sandbox.Engine.Utils
         public static bool ENABLE_GATLING_TURRETS = true;
         public static bool ENABLE_MISSILE_TURRETS = true;
         public static bool ENABLE_INTERIOR_TURRETS = true;
+        public static bool ENABLE_GENERIC_TURRETS = true;
 
         public static bool ENABLE_DAMAGED_COMPONENTS = false;
 

--- a/Sources/Sandbox.Game/Game/Weapons/Guns/MyGunBase.cs
+++ b/Sources/Sandbox.Game/Game/Weapons/Guns/MyGunBase.cs
@@ -465,6 +465,8 @@ namespace Sandbox.Game.Weapons
                 return new MyDefinitionId(typeof(MyObjectBuilder_WeaponDefinition), "LargeMissileTurret");
             else if (typeId == typeof(MyObjectBuilder_InteriorTurret))
                 return new MyDefinitionId(typeof(MyObjectBuilder_WeaponDefinition), "LargeInteriorTurret");
+            else if (typeId == typeof(MyObjectBuilder_LargeGenericTurret))
+                return new MyDefinitionId(typeof(MyObjectBuilder_WeaponDefinition), "LargeGenericTurret");
             else if (typeId == typeof(MyObjectBuilder_SmallMissileLauncher)
                 || typeId == typeof(MyObjectBuilder_SmallMissileLauncherReload))
                 return new MyDefinitionId(typeof(MyObjectBuilder_WeaponDefinition), "SmallMissileLauncher");

--- a/Sources/Sandbox.Game/Game/Weapons/Guns/MyLargeGenericTurret.cs
+++ b/Sources/Sandbox.Game/Game/Weapons/Guns/MyLargeGenericTurret.cs
@@ -1,0 +1,89 @@
+﻿using System.Text;
+using VRageMath;
+
+using Sandbox.Common.ObjectBuilders;
+using Sandbox.Game.Entities;
+
+using Sandbox.Definitions;
+using Sandbox.Common.ObjectBuilders.Definitions;
+using Sandbox.Game.Entities.Cube;
+using Sandbox.Engine.Utils;
+using VRage.Utils;
+using Sandbox.Game.Components;
+using Sandbox.ModAPI.Ingame;
+using VRage.Game;
+
+namespace Sandbox.Game.Weapons
+{
+    [MyCubeBlockType(typeof(MyObjectBuilder_LargeGenericTurret))]
+    class MyLargeGenericTurret : MyLargeConveyorTurretBase, IMyLargeGenericTurret
+    {
+        public int Burst { get; private set; }
+
+        public override void Init(MyObjectBuilder_CubeBlock objectBuilder, MyCubeGrid cubeGrid)
+        {
+            base.Init(objectBuilder, cubeGrid);
+
+            // User settings:
+            m_randomStandbyChangeConst_ms = MyUtils.GetRandomInt(3500, 4500);
+
+            if (m_gunBase.HasAmmoMagazines)
+                m_shootingCueEnum = m_gunBase.ShootSound;
+            m_rotatingCueEnum.Init("WepTurretInteriorRotate");
+
+            Render.NeedsDraw = true;
+        }
+
+        protected override float ForwardCameraOffset { get { return 0.1f; } }
+        protected override float UpCameraOffset { get { return 0.25f; } }
+
+        public override void Shoot(MyShootActionEnum action, Vector3 direction, string gunAction)
+        {
+            if (action != MyShootActionEnum.PrimaryAction)
+                return;
+
+            m_gunBase.Shoot(Vector3.Zero);
+        }
+
+        public override void OnModelChange()
+        {
+            base.OnModelChange();
+
+            if (IsFunctional)
+            {
+                m_base1 = Subparts["GenericTurretBase1"];
+                m_base2 = m_base1.Subparts["GenericTurretBase2"];
+                m_barrel = new MyLargeInteriorBarrel();
+                ((MyLargeInteriorBarrel)m_barrel).Init(m_base2, this);
+                GetCameraDummy();
+            }
+            else
+            {
+                m_base1 = null;
+                m_base2 = null;
+                m_barrel = null;
+            }
+
+            ResetRotation();
+        }
+
+
+        public override void UpdateAfterSimulation()
+        {
+            if (!MyFakes.ENABLE_GENERIC_TURRETS || !Sandbox.Game.World.MySession.Static.WeaponsEnabled)
+            {
+                RotateModels();
+                return;
+            }
+
+            base.UpdateAfterSimulation();
+
+            DrawLasers();
+        }
+
+        public MyLargeGenericTurret()
+        {
+            Render = new Components.MyRenderComponentLargeTurret();
+        }
+    }
+}

--- a/Sources/Sandbox.Game/Sandbox.Game.csproj
+++ b/Sources/Sandbox.Game/Sandbox.Game.csproj
@@ -954,6 +954,7 @@
     <Compile Include="Game\Screens\Terminal\Controls\MyTerminalControlListbox.cs" />
     <Compile Include="Game\VoiceChat\IMyVoiceChatLogic.cs" />
     <Compile Include="Game\VoiceChat\MyVoiceChatSessionComponent.cs" />
+    <Compile Include="Game\Weapons\Guns\MyLargeGenericTurret.cs" />
     <Compile Include="Game\Weapons\Guns\MyUserControllableGun.cs" />
     <Compile Include="Game\World\Environment\MyEnvironmentalParticleLogicFactory.cs" />
     <Compile Include="Game\World\Environment\MyEnvironmentalParticleLogicFireFly.cs" />

--- a/Sources/SpaceEngineers.ObjectBuilders/ObjectBuilders/MyObjectBuilder_LargeGenericTurret.cs
+++ b/Sources/SpaceEngineers.ObjectBuilders/ObjectBuilders/MyObjectBuilder_LargeGenericTurret.cs
@@ -1,0 +1,11 @@
+﻿using ProtoBuf;
+using VRage.ObjectBuilders;
+
+namespace Sandbox.Common.ObjectBuilders
+{
+    [ProtoContract]
+    [MyObjectBuilderDefinition]
+    public class MyObjectBuilder_LargeGenericTurret : MyObjectBuilder_ConveyorTurretBase
+    {
+    }
+}

--- a/Sources/SpaceEngineers.ObjectBuilders/SpaceEngineers.ObjectBuilders.csproj
+++ b/Sources/SpaceEngineers.ObjectBuilders/SpaceEngineers.ObjectBuilders.csproj
@@ -153,6 +153,7 @@
     <Compile Include="ObjectBuilders\MyObjectBuilder_Drill.cs" />
     <Compile Include="ObjectBuilders\MyObjectBuilder_ExtendedPistonBase.cs" />
     <Compile Include="ObjectBuilders\MyObjectBuilder_GasTank.cs" />
+    <Compile Include="ObjectBuilders\MyObjectBuilder_LargeGenericTurret.cs" />
     <Compile Include="ObjectBuilders\MyObjectBuilder_GravityGenerator.cs" />
     <Compile Include="ObjectBuilders\MyObjectBuilder_GravityGeneratorSphere.cs" />
     <Compile Include="ObjectBuilders\MyObjectBuilder_Gyro.cs" />

--- a/SpaceEngineers.sln
+++ b/SpaceEngineers.sln
@@ -72,6 +72,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Configuration", "Configuration", "{BB2E2FD7-114E-441E-A282-643353F31A64}"
 	ProjectSection(SolutionItems) = preProject
 		global.props = global.props
+		user.props = user.props
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VRage.Game", "Sources\VRage.Game\VRage.Game.csproj", "{4539B5F0-3316-40E6-B032-9FBCAFAAC5BE}"


### PR DESCRIPTION
Adds a new type of turret, LargeGenericTurret. It's a simple interior style turret, but with support for conveyor networks. Perfect for turrets that aren't gatling guns or rocket launchers, such as autocannons, tank guns and such.

Internally, the models use the same structure as the interior turrets, but named differently. The subpart for the turret body is GenericTurretBase1 and the subpart for the barrel(s) of the turret is GenericTurretBase2. Everything else behaves as a Space Engineers turret behaves. The main change was setting the base class from LargeTurretBase to LargeConveyorTurretBase. It's been tested and works.

It's more of a modding turret, as I was fed up with the limitations of the existing turrets. Gatling turrets require an extra model that you don't see with fixed barrel turrets, and the aim points for the turrets jitter; Rocket turrets have the "Reloading..." thing which isn't useful for large magazine, rapid fire turrets, and interior turrets, which are most useful from an actual shooting point of view can't link to conveyor systems. 

A perfect demo for this turret would be a converted version of the [Large Ship Cannon turret](http://steamcommunity.com/sharedfiles/filedetails/?id=402952773) example mod (which needs converting to DX11 anyway).