### PR TITLE
Soundblock Categories

### DIFF
--- a/Sources/SpaceEngineers.ObjectBuilders/ObjectBuilders/MyObjectBuilder_SoundBlock.cs
+++ b/Sources/SpaceEngineers.ObjectBuilders/ObjectBuilders/MyObjectBuilder_SoundBlock.cs
@@ -21,6 +21,9 @@ namespace Sandbox.Common.ObjectBuilders
         public string CueName = null;
 
         [ProtoMember]
+        public string SelectedCategory = null;
+
+        [ProtoMember]
         public float LoopPeriod = 1f;
 
         [ProtoMember]


### PR DESCRIPTION
This adds a second Listbox in the Soundblock Terminal which lists
Categories by either the SubtypeId or Displayname to help with huge
Soundlists. Only Sounds of the selected Category will be displayed in the "Sounds List" Listbox

[Screenshot ](http://steamcommunity.com/sharedfiles/filedetails/?id=639401144)