### PR TITLE
Added Properties to IMyPlayer and IMyIdentity

### DIFF
--- a/Sources/Sandbox.Game/ModAPI/MyCharacter_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/MyCharacter_ModAPI.cs
@@ -52,8 +52,18 @@ namespace Sandbox.Game.Entities.Character
         }
 
         IMyInventory IMyInventoryOwner.GetInventory(int index)
-        {            
+        {
             return MyEntityExtensions.GetInventory(this, index);
+        }
+
+        VRage.Game.MyCharacterMovementEnum VRage.Game.ModAPI.IMyCharacter.GetCurrentMovementState()
+        {
+            return this.GetCurrentMovementState();
+        }
+
+        VRage.Game.ModAPI.IMyPlayer VRage.Game.ModAPI.IMyCharacter.GetPlayer()
+        {
+            return Sandbox.Game.World.MyPlayer.GetPlayerFromCharacter(this);
         }
     }
 }

--- a/Sources/Sandbox.Game/ModAPI/MyIdentity_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/MyIdentity_ModAPI.cs
@@ -38,5 +38,11 @@ namespace Sandbox.Game.World
         {
             get { return IsDead; }
         }
+
+        IMyCharacter IMyIdentity.Character
+        {
+            get { return Character; }
+        }
+
     }
 }

--- a/Sources/Sandbox.Game/ModAPI/MyPlayer_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/MyPlayer_ModAPI.cs
@@ -78,5 +78,26 @@ namespace Sandbox.Game.World
         {
             get { return IsPromoted; }
         }
+
+        IMyIdentity IMyPlayer.Identity
+        {
+            get { return Identity; }
+        }
+
+        IMyCharacter IMyPlayer.Character
+        {
+            get { return Character; }
+        }
+
+        bool IMyPlayer.IsRealPlayer
+        {
+            get { return IsRealPlayer; }
+        }
+
+        bool IMyPlayer.IsBot
+        {
+            get { return IsBot; }
+        }
+
     }
 }

--- a/Sources/VRage.Game/ModAPI/IMyCharacter.cs
+++ b/Sources/VRage.Game/ModAPI/IMyCharacter.cs
@@ -45,5 +45,9 @@ namespace VRage.Game.ModAPI
         /// <param name="eventName">Event name.</param>
         /// <param name="sync">Synchronize over network</param>
 	    void TriggerCharacterAnimationEvent(string eventName, bool sync);
+
+        MyCharacterMovementEnum GetCurrentMovementState();
+
+        IMyPlayer GetPlayer();
     }
 }

--- a/Sources/VRage.Game/ModAPI/IMyIdentity.cs
+++ b/Sources/VRage.Game/ModAPI/IMyIdentity.cs
@@ -4,11 +4,13 @@ namespace VRage.Game.ModAPI
 {
     public interface IMyIdentity
     {
+        [System.Obsolete("use IdentityId")]
         long PlayerId { get; }
         long IdentityId { get; }
         string DisplayName { get; }
         string Model { get; }
         Vector3? ColorMask { get; }
         bool IsDead { get; }
+        IMyCharacter Character { get; }
     }
 }

--- a/Sources/VRage.Game/ModAPI/IMyPlayer.cs
+++ b/Sources/VRage.Game/ModAPI/IMyPlayer.cs
@@ -14,9 +14,14 @@ namespace VRage.Game.ModAPI
         VRageMath.Vector3D GetPosition();
         ulong SteamUserId { get; }
         string DisplayName { get; }
+        [System.Obsolete("use IdentityId")]
         long PlayerID { get; }
         long IdentityId { get; }
         bool IsAdmin { get; }
         bool IsPromoted { get; }
+        IMyIdentity Identity { get; }
+        IMyCharacter Character { get; }
+        bool IsRealPlayer { get; }
+        bool IsBot { get; }
     }
 }


### PR DESCRIPTION
Makes it easier for mods to move between IMyPlayer, IMyIdentity, and IMyCharacter.
Adds tests for whether a player is a human or a bot to IMyPlayer.
Adds property for current movement state to IMyCharacter.

The goal here is to give mods more information about characters so they can react accordingly.
For my purposes, it would be very useful to know whether a character is a human or a bot, and whether or not a character is alive.