### PR TITLE
[FIX] Inventory transfer failure bug

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Inventory/MyInventory.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Inventory/MyInventory.cs
@@ -1182,12 +1182,31 @@ namespace Sandbox.Game
 
             FixTransferAmount(src, dst, srcItem, spawn, ref remove, ref amount);
 
-            if (amount != 0)
+            //If dst == src we need to remove first or AddItems could fail.
+            
+            if (dst == src)
             {
-                if (dst.AddItems(amount, srcItem.Value.Content, dst == src && remove == 0 ? itemId : (uint?)null, destItemIndex))
+                if (remove != 0)
                 {
-                    if (remove != 0)
-                        src.RemoveItems(itemId, remove);
+                    src.RemoveItems(itemId, remove);
+
+                    if (amount != 0)
+                    {
+                        dst.AddItems(amount, srcItem.Value.Content, (uint?)null, destItemIndex);
+                    }
+                }
+            }
+            else
+            {
+                if (amount != 0)
+                {
+                    if (dst.AddItems(amount, srcItem.Value.Content, (uint?)null, destItemIndex))
+                    {
+                        if (remove != 0)
+                        {
+                            src.RemoveItems(itemId, remove);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR fixes the issue where an inventory item could not be moved from one index to another in the same inventory if the amount was greater than the free space in the inventory. I solved this by checking if the source and destination inventories are identical, and if so remove the item before adding it at the new index to prevent AddItems from failing.

I do have a concern regarding my changes, and that is that the ternary operator in the original code used in AddItems would now never evaluate to true. If that is going to cause problems please let me know.