### PR TITLE
[FEATURE/QoL] Add ingame IMyThrust properties MaxThrust and CurrentThrust

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyThrust.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyThrust.cs
@@ -8,5 +8,7 @@ namespace Sandbox.ModAPI.Ingame
     public interface IMyThrust: IMyFunctionalBlock
     {
         float ThrustOverride { get;}
+        float MaxThrust { get; }
+        float CurrentThrust { get; }
     }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyThrust.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyThrust.cs
@@ -672,6 +672,22 @@ namespace Sandbox.Game.Entities
             }
         }
 
+        float Sandbox.ModAPI.Ingame.IMyThrust.MaxThrust
+        {
+            get
+            {
+                return BlockDefinition.ForceMagnitude * m_thrustMultiplier;
+            }
+        }
+
+        float Sandbox.ModAPI.Ingame.IMyThrust.CurrentThrust
+        {
+            get
+            {
+                return CurrentStrength * BlockDefinition.ForceMagnitude * m_thrustMultiplier;
+            }
+        }
+
         private MyMultilineConveyorEndpoint m_conveyorEndpoint;
         public IMyConveyorEndpoint ConveyorEndpoint { get { return m_conveyorEndpoint; } }
         public void InitializeConveyorEndpoint()


### PR DESCRIPTION
This PR adds two new properties to Sandbox.ModAPI.Ingame.IMyThrust that allows ingame scripts to get the max thrust of a thruster (includes atmosphere multiplier) as well as the current actual thrust output.