### PR TITLE
[Feature] Incomplete / Damaged blocks are lighter than complete blocks

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBlockCollector.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBlockCollector.cs
@@ -396,7 +396,7 @@ namespace Sandbox.Game.Entities.Cube
 
         void AddMass(MySlimBlock block, IDictionary<Vector3I, HkMassElement> massResults)
         {
-            float mass = block.BlockDefinition.Mass;
+            float mass = block.GetMass();
             if (MyFakes.ENABLE_COMPOUND_BLOCKS && block.FatBlock is MyCompoundCubeBlock)
             {
                 mass = 0f;

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeGrid.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeGrid.cs
@@ -4145,6 +4145,7 @@ namespace Sandbox.Game.Entities
             if (block != null)
             {
                 block.SetIntegrity(buildIntegrity, integrity, integrityChangeType, grinderOwner);
+                Physics.UpdateMass();
             }
         }
 

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MySlimBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MySlimBlock.cs
@@ -1915,7 +1915,7 @@ namespace Sandbox.Game.Entities.Cube
         public float GetMass()
         {
             if (FatBlock != null)
-                return FatBlock.GetMass();
+                return FatBlock.GetMass() * Integrity / MaxIntegrity;
             Matrix m;
             if (MyDestructionData.Static != null)
                 return MyDestructionData.Static.GetBlockMass(CalculateCurrentModel(out m), BlockDefinition);


### PR DESCRIPTION
1. grids recalculate grid mass after an integrity change ( ie a block is cut / damage )
2. grids use the actual block mass instead of the template mass
3. blocks now calculate mass using the ratio of Integrity / MaxIntegrity

Testing
1. limited x64 testing. Physically blocks appeared to behave as expected ( no weird negative mass issues )
2. no x86 testing, memory error prevented me from testing x86.

Issues
1. Ship Controller's report mass in correctly. still tracking down the source of this problem. Anyone got ideas?