### PR TITLE
Allow modAPI (script) access to OnGridChanged events.

### DIFF
--- a/Sources/Sandbox.Game/ModAPI/Blocks/MyCubeGrid_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/Blocks/MyCubeGrid_ModAPI.cs
@@ -247,6 +247,12 @@ namespace Sandbox.Game.Entities
             remove { OnBlockOwnershipChanged -= GetDelegate(value); }
         }
 
+        event Action<IMyCubeGrid> IMyCubeGrid.OnGridChanged
+        {
+            add { OnGridChanged += GetDelegate(value); }
+            remove { OnGridChanged -= GetDelegate(value); }
+        }
+
         VRage.Game.ModAPI.Ingame.IMySlimBlock VRage.Game.ModAPI.Ingame.IMyCubeGrid.GetCubeBlock(Vector3I position)
         {
             VRage.Game.ModAPI.Ingame.IMySlimBlock block = GetCubeBlock(position);

--- a/Sources/VRage.Game/ModAPI/IMyCubeGrid.cs
+++ b/Sources/VRage.Game/ModAPI/IMyCubeGrid.cs
@@ -241,6 +241,7 @@ namespace VRage.Game.ModAPI
         event Action<IMySlimBlock> OnBlockAdded;
         event Action<IMySlimBlock> OnBlockRemoved;
         event Action<IMyCubeGrid> OnBlockOwnershipChanged;
+        event Action<IMyCubeGrid> OnGridChanged;
 
         void UpdateOwnership(long ownerId, bool isFunctional);
         VRageMath.Vector3I WorldToGridInteger(VRageMath.Vector3D coords);


### PR DESCRIPTION
OnGridChanged is used in the cargoship code to detect when a Player has
taken over a ship so it doesn't despawn.

It's not possible to create the same functionality with other available
events, which can be triggered by things like minor damage to ships, or
unpowered ships drifting.