### PR TITLE
Fix for lag when recoloring blocks

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeGrid.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeGrid.cs
@@ -4688,7 +4688,7 @@ namespace Sandbox.Game.Entities
                 if (block.ColorMaskHSV == newHSV)
                     return false;
                 block.ColorMaskHSV = newHSV;
-                block.UpdateVisual();
+                block.UpdateVisual(false); //Physics wasn't affected by color change
                 return true;
             }
             finally

--- a/Sources/Sandbox.Game/Game/Entities/Cube/MySlimBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MySlimBlock.cs
@@ -1312,7 +1312,7 @@ namespace Sandbox.Game.Entities.Cube
             ProfilerShort.End();
         }
 
-        public void UpdateVisual()
+        public void UpdateVisual(bool physicsChanged = true)
         {
             UpdateShowParts();
 
@@ -1338,7 +1338,7 @@ namespace Sandbox.Game.Entities.Cube
                 FatBlock = null;
             }
             CubeGrid.SetBlockDirty(this);
-            if (CubeGrid.Physics != null)
+            if (CubeGrid.Physics != null && physicsChanged)
             {
                 CubeGrid.Physics.AddDirtyArea(Min, Max);
             }


### PR DESCRIPTION
When recoloring blocks on a big surface, sim-speed would drop and fps would drop (even though it doesn't in debug view).

It was marking the blocks as "dirty" which would cause the Havok physics shape to be recalculated every time blocks were being painted, however the physics shape would never change when the color changed. 

You can see performance differences in this screenshot. http://imgur.com/xXWBOnb or in this youtube video. https://youtu.be/ytw4v7cd-kg
