### PR TITLE
Fix: DX11 renderer is unable to load LOD models from mods directories.

### DIFF
--- a/Sources/VRage.Render11/GeometryStage/Geometry/MyMeshes.cs
+++ b/Sources/VRage.Render11/GeometryStage/Geometry/MyMeshes.cs
@@ -2112,6 +2112,7 @@ namespace VRageRender
             StoreLodMeshSections(id, 0, ref sections);
 
             int modelLods = 1;
+            var mainMeshDir = Path.IsPathRooted(assetName) ? Path.GetDirectoryName(assetName) : Path.GetDirectoryName(Path.Combine(MyFileSystem.ContentPath, assetName));
 
             if (lodDescriptors != null)
             for (int i = 0; i < lodDescriptors.Length; i++)
@@ -2124,7 +2125,7 @@ namespace VRageRender
 
                 MyLodMeshInfo lodMesh = new MyLodMeshInfo
                 {
-                    FileName = meshFile,
+                    FileName = Path.Combine(mainMeshDir, Path.GetFileName(meshFile)),
                     LodDistance = lodDescriptors[i].Distance,
                     NullLodMesh = meshFile == null,
                 };


### PR DESCRIPTION
The change forces LOD model files to be loaded from the same path as
main model file. The bug was reported here:
http://forums.keenswh.com/threads/1-105-directx-11-renderer-is-unable-to-load-level-of-detail-models.7371600/