### PR TITLE
Remove ability to blueprint enemy ships while in survival mode

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBuilder.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Cube/MyCubeBuilder.cs
@@ -1742,20 +1742,40 @@ namespace Sandbox.Game.Entities
                 {
                     MySessionComponentVoxelHand.Static.Enabled = false;
                     var copiedGrid = MyCubeGrid.GetTargetGrid();
-                    if (!MyInput.Static.IsAnyShiftKeyPressed())
-                        m_clipboard.CopyGroup(copiedGrid, MyInput.Static.IsAnyAltKeyPressed() ? GridLinkTypeEnum.Physical : GridLinkTypeEnum.Logical);
-                    else
-                        m_clipboard.CopyGrid(copiedGrid);
-
-                    UpdatePasteNotification(MyCommonTexts.CubeBuilderPasteNotification);
-
-                    var blueprintScreen = new MyGuiBlueprintScreen(m_clipboard);
-                    if (copiedGrid != null)
+                    Boolean ownerInplayerFaction = false;
+                    var faction = MySession.Static.Factions.TryGetPlayerFaction(MySession.Static.LocalPlayerId);
+                    for (int i = 0; i < copiedGrid.BigOwners.Count; i++ )
                     {
-                        blueprintScreen.CreateFromClipboard(true);
+                        if (faction != null)
+                        {
+                            if (MySession.Static.Factions.TryGetPlayerFaction(copiedGrid.BigOwners[i]) == faction)
+                            {
+                                ownerInplayerFaction = true;
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            break;
+                        }
                     }
-                    m_clipboard.Deactivate();
-                    MyGuiSandbox.AddScreen(blueprintScreen);
+                    if (copiedGrid.BigOwners.Contains(MySession.Static.LocalPlayerId) || ownerInplayerFaction || !MySession.Static.SurvivalMode || copiedGrid.BigOwners.Count == 0) //If player owns ship, or owner is in players faction, or in creative mode or ship is neutral
+                    {
+                        if (!MyInput.Static.IsAnyShiftKeyPressed())
+                            m_clipboard.CopyGroup(copiedGrid, MyInput.Static.IsAnyAltKeyPressed() ? GridLinkTypeEnum.Physical : GridLinkTypeEnum.Logical);
+                        else
+                            m_clipboard.CopyGrid(copiedGrid);
+
+                        UpdatePasteNotification(MyCommonTexts.CubeBuilderPasteNotification);
+
+                        var blueprintScreen = new MyGuiBlueprintScreen(m_clipboard);
+                        if (copiedGrid != null)
+                        {
+                            blueprintScreen.CreateFromClipboard(true);
+                        }
+                        m_clipboard.Deactivate();
+                        MyGuiSandbox.AddScreen(blueprintScreen);
+                    }
                 }
                 return true;
             }


### PR DESCRIPTION
Initial issue: Player were able to get the blueprint of an enemy ship (Ctrl+B) which they could then project, build in creative and explore for weaknesses.

Fix: Players will not be able to get the blueprint of a ship if they are not the owner, or if the owner is not in their faction. Players will still be able to get blueprints of a completely neural ship, and players will be able to blueprint any ship while in creative mode.