### PR TITLE
Fixed reduced damage from Missiles when multiple are shot at once

### DIFF
--- a/Sources/Sandbox.Game/Game/ParticleEffects/MyExplosion.cs
+++ b/Sources/Sandbox.Game/Game/ParticleEffects/MyExplosion.cs
@@ -549,6 +549,13 @@ namespace Sandbox.Game
                     }
                 }
 
+                //Special case for other Missiles
+                var missile = entity as MyMissile;
+                if (missile != null)
+                {
+                    continue;
+                }
+
                 var raycastDamageInfo = explosionDamageInfo.ExplosionDamage.ComputeDamageForEntity(entity.PositionComp.WorldAABB.Center);
                 float damage = raycastDamageInfo.DamageRemaining;
 


### PR DESCRIPTION
Originally Missiles would cause eachother to blow up, expecially when multiple are shot at once, and even worse if shot from an angle. This would weaken the overall damage of the explosion when multiple rockets go off near eachother, either by blowing the rocket up, or reducing the damage of each individual rocket by damaging the rockets instead of damaging the blocks. Missile explosions will now not effect other missiles, as it serves no gameplay purpose, other than causing multiple rockets to deal minimal damage. Gatling turrets can still shoot down missiles. 

Made a video to demonstrate the change: https://youtu.be/gcHqaJlkkAA
(16 Missiles are fired at once, at large ship heavy armour blocks)