### PR TITLE
Programmable block better exception handling

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
@@ -181,11 +181,6 @@ public void Main(string argument) {{
                 return false;
             }
 
-            if (!IsFunctional || !IsWorking)
-            {
-                return false;
-            }
-
             string response;
             var result = this.ExecuteCode(argument ?? "", out response);
             SetDetailedInfo(response);

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
@@ -456,6 +456,16 @@ public void Main(string argument) {{
                     }
                 } else {
                     response += MyTexts.GetString(MySpaceTexts.ProgrammableBlock_Exception_ExceptionCaught) + ex.Message;
+                    // Get both StackTraces
+                    string ExceptionStackTrace = ex.StackTrace;
+                    string[] currentStackTrace = Environment.StackTrace.Split(new string[] {Environment.NewLine}, StringSplitOptions.None);
+                    // Remove All Calls before the Script Call
+                    for (int i = 0; i < currentStackTrace.Length; i++)
+                    {
+                        ExceptionStackTrace.Replace(currentStackTrace[i], "");
+                    }
+                    // Add Script StackTrace to response Line
+                    response += "\n" + ExceptionStackTrace;
                     OnProgramTermination(ScriptTerminationReason.RuntimeException);
                 }
                 return m_terminationReason;


### PR DESCRIPTION
Hi,

Because I hated those simple "an exception occured" messages and always wanted to know where exactly the Exception occurd, I added the Scripts StackTrace to the DetailedInfo, so the Programmer knows where to search for the Problem.
Also I found that there wasa double check if the Block is actually Powered and Functional. I removed that double check.

This is my first .NET programming I have ever made, so feel free to give feedback about my changes. Before I programmed in Jave and Scripted in SpaceEngineers.

Greetings
Pingger