### PR TITLE
Fix for LCD panels not updating text if the grid is not synchronized

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyTextPanel.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyTextPanel.cs
@@ -1195,51 +1195,62 @@ namespace Sandbox.Game.Entities.Blocks
 
         private void SendChangeDescriptionMessage(StringBuilder description, bool isPublic)
         {
-            if (description.CompareTo(PublicDescription) == 0 && isPublic)
+            // update the text directly if the grid isn't synchronized
+            if (CubeGrid.IsPreview || !CubeGrid.SyncFlag)
             {
-                return;
-            }
-
-            if (description.CompareTo(PrivateDescription) == 0 && isPublic == false)
-            {
-                return;
-            }
-            //This causes text changed twice. Other fix will be to remove CompareUpdate from public or private description set method above
-            /*
-            if(isPublic)
-            {
-                PublicDescription = description;
+                if (isPublic)
+                {
+                    PublicDescription = description;
+                }
+                else
+                {
+                    PrivateDescription = description;
+                }
             }
             else
             {
-                PrivateDescription = description;
+                if (isPublic && description.CompareTo(PublicDescription) == 0)
+                {
+                    return;
+                }
+
+                if (!isPublic && description.CompareTo(PrivateDescription) == 0)
+                {
+                    return;
+                }
+
+                MyMultiplayer.RaiseEvent(this, x => x.OnChangeDescription, description.ToString(), isPublic);
             }
-            */
-            MyMultiplayer.RaiseEvent(this, x => x.OnChangeDescription, description.ToString(), isPublic);
         }
 
         private void SendChangeTitleMessage(StringBuilder title, bool isPublic)
         {
-            if (title.CompareTo(PublicTitle) == 0 && isPublic)
+            // update the title directly if the grid isn't synchronized
+            if (CubeGrid.IsPreview || !CubeGrid.SyncFlag)
             {
-                return;
-            }
-
-            if (title.CompareTo(PrivateTitle) == 0 && isPublic == false)
-            {
-                return;
-            }
-
-            if (isPublic)
-            {
-                PublicTitle = title;
+                if (isPublic)
+                {
+                    PublicTitle = title;
+                }
+                else
+                {
+                    PrivateTitle = title;
+                }
             }
             else
             {
-                PrivateTitle = title;
-            }
+                if (isPublic && title.CompareTo(PublicTitle) == 0)
+                {
+                    return;
+                }
 
-            MyMultiplayer.RaiseEvent(this, x => x.OnChangeTitle, title.ToString(), isPublic);
+                if (!isPublic && title.CompareTo(PrivateTitle) == 0)
+                {
+                    return;
+                }
+
+                MyMultiplayer.RaiseEvent(this, x => x.OnChangeTitle, title.ToString(), isPublic);
+            }
         }
 
         #endregion


### PR DESCRIPTION
### The problem
Mods that spawn client-only grids (like my Helmet mod: http://steamcommunity.com/sharedfiles/filedetails/?id=428842256 ) are not be able to update the text on LCDs from MP clients' perspective.

### What this PR does
Makes the TextPanel's text/title setter take grid synchronization into account.

If the TextPanel's grid is not synchronized then the text/title will be locally set without raising the change text/title event.

Apart from fixing the problem, this also saves bandwidth by not sending network packets from clients to server to update nonexistent entities.

But if the TextPanel's grid is synchronized, it will raise the change text/title event, just as before.

Also a small optimization with the CompareTo() conditions, moved the isPublic at the start to avoid unnecessary CompareTo() calls.

### Tested
I've tested this locally and on a DS with the helmet mod and the vanilla LCDs.