### PR TITLE
Fix VRage.Input.dll not included for mod compilation

### DIFF
--- a/Sources/SpaceEngineers.Game/MySpaceGameCustomInitialization.cs
+++ b/Sources/SpaceEngineers.Game/MySpaceGameCustomInitialization.cs
@@ -25,6 +25,7 @@ namespace SpaceEngineers.Game
                 ,Path.Combine(MyFileSystem.ExePath, "VRage.Library.dll")
                 ,Path.Combine(MyFileSystem.ExePath, "VRage.Math.dll")
                 ,Path.Combine(MyFileSystem.ExePath, "VRage.Game.dll")
+                ,Path.Combine(MyFileSystem.ExePath, "VRage.Input.dll")
                 ,"System.Core.dll"
                 ,"System.dll"
                 ,Path.Combine(MyFileSystem.ExePath, "SpaceEngineers.ObjectBuilders.dll")


### PR DESCRIPTION
TL;DR: **Every single mod that uses MyAPIGateway.Input is broken, this 1-line addition fixes it.**.

Bug report: http://forums.keenswh.com/threads/1-137-006-ilcompiler-missing-reference-to-vrage-input-dll.7384740/#post-1286985100