### PR TITLE
fix missing references for github users

### DIFF
--- a/Sources/Sandbox.Game/Sandbox.Game.csproj
+++ b/Sources/Sandbox.Game/Sandbox.Game.csproj
@@ -126,10 +126,14 @@
   <PropertyGroup>
     <HavokWrapperFullPath>..\..\3rd\$(HavokDir)\Release\$(Platform)\HavokWrapper.dll</HavokWrapperFullPath>
   </PropertyGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(SolutionDir)\global.props" Condition="exists('$(SolutionDir)\global.props')" />
+  </ImportGroup>
   <ItemGroup>
     <Reference Include="HavokWrapper">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(HavokWrapperFullPath)</HintPath>
+      <HintPath Condition="Exists($(HavokWrapperFullPath))">$(HavokWrapperFullPath)</HintPath>
+      <HintPath Condition="'$(Platform)' == 'x64'">$(SteamBin64)\HavokWrapper.dll</HintPath>
     </Reference>
     <Reference Include="InfinarioSDK">
       <HintPath>..\..\3rd\Infinario\InfinarioSDK.dll</HintPath>
@@ -155,14 +159,16 @@
       <HintPath>..\..\3rd\SharpDX\SharpDX.Mathematics.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX.Toolkit">
-      <HintPath>..\..\3rd\SharpDX.Toolkit\x64\Release\SharpDX.Toolkit.dll</HintPath>
+      <HintPath Condition="Exists('..\..\3rd\SharpDX.Toolkit\x64\Release\SharpDX.Toolkit.dll')">..\..\3rd\SharpDX.Toolkit\x64\Release\SharpDX.Toolkit.dll</HintPath>
+      <HintPath Condition="'$(Platform)' == 'x64'">$(SteamBin64)\SharpDX.Toolkit.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX.XAudio2">
       <HintPath>..\..\3rd\SharpDX\SharpDX.XAudio2.dll</HintPath>
     </Reference>
     <Reference Include="SteamSDK" Condition="('$(Configuration)' != 'Debug_XB1') And ('$(Configuration)' != 'Release_XB1')">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\3rd\SteamSDK\$(Configuration)\$(Platform)\SteamSDK.dll</HintPath>
+      <HintPath Condition="Exists('..\..\3rd\SteamSDK\$(Configuration)\$(Platform)\SteamSDK.dll')">..\..\3rd\SteamSDK\$(Configuration)\$(Platform)\SteamSDK.dll</HintPath>
+      <HintPath Condition="'$(Platform)' == 'x64'">$(SteamBin64)\SteamSDK.dll</HintPath>
     </Reference>
     <Reference Include="RakNet">
       <SpecificVersion>False</SpecificVersion>
@@ -186,7 +192,14 @@
     <Reference Include="System.Xml" />
     <Reference Include="VRage.Native">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\3rd\VRage.Native\release\$(Platform)\VRage.Native.dll</HintPath>
+      <HintPath Condition="Exists('..\..\3rd\VRage.Native\release\$(Platform)\VRage.Native.dll')">..\..\3rd\VRage.Native\release\$(Platform)\VRage.Native.dll</HintPath>
+      <HintPath Condition="'$(Platform)' == 'x64'">$(SteamBin64)\VRage.Native.dll</HintPath>
+    </Reference>
+    <Reference Condition="!Exists('..\VRage.Scripting\VRage.Scripting.csproj') And '$(Platform)' == 'x64'" Include="VRage.Scripting">
+      <HintPath>$(SteamBin64)\VRage.Scripting.dll</HintPath>
+    </Reference>
+    <Reference Condition="!Exists('..\VRage.OpenVRWrapper\VRage.OpenVRWrapper.csproj') And '$(Platform)' == 'x64'" Include="VRage.OpenVRWrapper">
+      <HintPath>$(SteamBin64)\VRage.OpenVRWrapper.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Sources/SpaceEngineers.Game/SpaceEngineers.Game.csproj
+++ b/Sources/SpaceEngineers.Game/SpaceEngineers.Game.csproj
@@ -102,14 +102,19 @@
   <PropertyGroup>
     <RootNamespace>SpaceEngineers.Game</RootNamespace>
   </PropertyGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(SolutionDir)\global.props" Condition="exists('$(SolutionDir)\global.props')" />
+  </ImportGroup>
   <ItemGroup>
     <Reference Include="HavokWrapper">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(HavokWrapperFullPath)</HintPath>
+      <HintPath Condition="Exists($(HavokWrapperFullPath))">$(HavokWrapperFullPath)</HintPath>
+      <HintPath Condition="'$(Platform)' == 'x64'">$(SteamBin64)\HavokWrapper.dll</HintPath>
     </Reference>
     <Reference Include="SteamSDK">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\3rd\SteamSDK\$(Configuration)\$(Platform)\SteamSDK.dll</HintPath>
+      <HintPath Condition="Exists('..\..\3rd\SteamSDK\$(Configuration)\$(Platform)\SteamSDK.dll')">..\..\3rd\SteamSDK\$(Configuration)\$(Platform)\SteamSDK.dll</HintPath>
+      <HintPath Condition="'$(Platform)' == 'x64'">$(SteamBin64)\SteamSDK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -118,6 +123,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Condition="!Exists('..\VRage.Scripting\VRage.Scripting.csproj') And '$(Platform)' == 'x64'" Include="VRage.Scripting">
+      <HintPath>$(SteamBin64)\VRage.Scripting.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AI\MySpaceBotFactory.cs" />

--- a/Sources/VRage.Game/VRage.Game.csproj
+++ b/Sources/VRage.Game/VRage.Game.csproj
@@ -128,10 +128,14 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(SolutionDir)\global.props" Condition="exists('$(SolutionDir)\global.props')" />
+  </ImportGroup>
   <ItemGroup>
     <Reference Include="HavokWrapper">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(HavokWrapperFullPath)</HintPath>
+      <HintPath Condition="Exists($(HavokWrapperFullPath))">$(HavokWrapperFullPath)</HintPath>
+      <HintPath Condition="'$(Platform)' == 'x64'">$(SteamBin64)\HavokWrapper.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/Sources/VRage.Input/VRage.Input.csproj
+++ b/Sources/VRage.Input/VRage.Input.csproj
@@ -108,6 +108,9 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(SolutionDir)\global.props" Condition="exists('$(SolutionDir)\global.props')" />
+  </ImportGroup>
   <ItemGroup>
     <Reference Include="SharpDX">
       <HintPath>..\..\3rd\SharpDX\SharpDX.dll</HintPath>
@@ -127,7 +130,10 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Windows.Forms" />
-	<Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime" />
+    <Reference Condition="!Exists('..\VRage.OpenVRWrapper\VRage.OpenVRWrapper.csproj') And '$(Platform)' == 'x64'" Include="VRage.OpenVRWrapper">
+      <HintPath>$(SteamBin64)\VRage.OpenVRWrapper.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Input\IMyControlNameLookup.cs" />

--- a/Sources/VRage.Network/VRage.Network.csproj
+++ b/Sources/VRage.Network/VRage.Network.csproj
@@ -115,8 +115,8 @@
     <Compile Include="IMyServerCallback.cs" />
     <Compile Include="MyChannelEnum.cs" />
     <Compile Include="MyClientEntry.cs" />
-    <Compile Include="MyRakNetConnectionException.cs" />
-    <Compile Include="MyRakNetStartupException.cs" />
+    <Compile Condition="Exists('..\..\3rd\RakNet\$(Configuration)\$(Platform)\RakNet.dll')" Include="MyRakNetConnectionException.cs" />
+    <Compile Condition="Exists('..\..\3rd\RakNet\$(Configuration)\$(Platform)\RakNet.dll')" Include="MyRakNetStartupException.cs" />
     <Compile Include="MyRakNetClient.cs" />
     <Compile Include="MyRakNetLogger.cs" />
     <Compile Include="MyRakNetPeer.cs" />

--- a/Sources/VRage.Render11/VRage.Render11.csproj
+++ b/Sources/VRage.Render11/VRage.Render11.csproj
@@ -103,6 +103,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(SolutionDir)\global.props" Condition="exists('$(SolutionDir)\global.props')" />
+  </ImportGroup>
   <ItemGroup>
     <Reference Include="SharpDX">
       <HintPath>..\..\3rd\SharpDX\SharpDX.dll</HintPath>
@@ -126,7 +129,8 @@
       <HintPath>..\..\3rd\SharpDX\SharpDX.Mathematics.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX.Toolkit">
-      <HintPath>..\..\3rd\SharpDX.Toolkit\x64\Release\SharpDX.Toolkit.dll</HintPath>
+      <HintPath Condition="Exists('..\..\3rd\SharpDX.Toolkit\x64\Release\SharpDX.Toolkit.dll')">..\..\3rd\SharpDX.Toolkit\x64\Release\SharpDX.Toolkit.dll</HintPath>
+      <HintPath Condition="'$(Platform)' == 'x64'">$(SteamBin64)\SharpDX.Toolkit.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -138,6 +142,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Condition="!Exists('..\VRage.OpenVRWrapper\VRage.OpenVRWrapper.csproj') And '$(Platform)' == 'x64'" Include="VRage.OpenVRWrapper">
+      <HintPath>$(SteamBin64)\VRage.OpenVRWrapper.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\Callbacks.cs" />

--- a/Sources/VRage.Scripting/VRage.Scripting.csproj
+++ b/Sources/VRage.Scripting/VRage.Scripting.csproj
@@ -32,21 +32,28 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(SolutionDir)\global.props" Condition="exists('$(SolutionDir)\global.props')" />
+  </ImportGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\3rd\Microsoft.CodeAnalysis\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath Condition="Exists('..\..\3rd\Microsoft.CodeAnalysis\Microsoft.CodeAnalysis.dll')">..\..\3rd\Microsoft.CodeAnalysis\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath Condition="'$(Platform)' == 'x64'">$(SteamBin64)\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\3rd\Microsoft.CodeAnalysis\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath Condition="Exists('..\..\3rd\Microsoft.CodeAnalysis\Microsoft.CodeAnalysis.CSharp.dll')">..\..\3rd\Microsoft.CodeAnalysis\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath Condition="'$(Platform)' == 'x64'">$(SteamBin64)\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\3rd\Microsoft.CodeAnalysis\System.Collections.Immutable.dll</HintPath>
+      <HintPath Condition="Exists('..\..\3rd\Microsoft.CodeAnalysis\System.Collections.Immutable.dll')">..\..\3rd\Microsoft.CodeAnalysis\System.Collections.Immutable.dll</HintPath>
+      <HintPath Condition="'$(Platform)' == 'x64'">$(SteamBin64)\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\3rd\Microsoft.CodeAnalysis\System.Reflection.Metadata.dll</HintPath>
+      <HintPath Condition="Exists('..\..\3rd\Microsoft.CodeAnalysis\System.Reflection.Metadata.dll')">..\..\3rd\Microsoft.CodeAnalysis\System.Reflection.Metadata.dll</HintPath>
+      <HintPath Condition="'$(Platform)' == 'x64'">$(SteamBin64)\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/global.props
+++ b/global.props
@@ -13,4 +13,7 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="$(SolutionDir)\user.props" Condition="exists('$(SolutionDir)\user.props')" />
   </ImportGroup>
+  <PropertyGroup>
+    <SteamBin64>$(ContentPath)\..\Bin64</SteamBin64>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
For references that are not included in github source, if the reference
is not where expected, change the path to steam's Bin64 folder.
Also prevents RakNet exceptions from compiling if RakNet.dll is missing

Tested with Debug/x64 and Release/x64.
