### PR TITLE
Fix projectors not working in offline mode

### DIFF
--- a/Sources/Sandbox.Game/Game/World/MySession.cs
+++ b/Sources/Sandbox.Game/Game/World/MySession.cs
@@ -402,7 +402,7 @@ namespace Sandbox.Game.World
         HashSet<ulong> m_adminMode = new HashSet<ulong>();
         public bool IsAdminModeEnabled(ulong user)
         {
-            return m_adminMode.Contains(user) && HasPlayerAdminRights(user);
+            return m_adminMode.Contains(user) || HasPlayerAdminRights(user);
         }
 
         public void EnableAdminMode(ulong user,bool value)


### PR DESCRIPTION
I'm not 100% sure this is the correct fix, however the current functionality ignores players in offline mode as admins as m_adminMode does not contain the user. MySession.Static.IsCopyPastingEnabled thus returns false.

Due to the fact that projectors specifically check for if IsCopyPastingEnabled the false flag stops any blueprints in offline mode from working.