### PR TITLE
Change MyGridProgram "Storage" property to enforce a max length

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/MyGridProgram.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/MyGridProgram.cs
@@ -36,6 +36,7 @@ namespace Sandbox.ModAPI.Ingame
         // WARNING: Do not autoinitialize any of these fields, or the grid program initialization process
         // will fail.
         private string m_storage;
+        private const int MAX_STORAGE_LENGTH = 8000;
         private readonly Action<string> m_main;
         private readonly Action m_save;
 
@@ -92,7 +93,15 @@ namespace Sandbox.ModAPI.Ingame
         public virtual string Storage
         {
             get { return this.m_storage ?? ""; }
-            protected set { this.m_storage = value ?? ""; }
+            protected set
+            {
+                if (value != null && value.Length > MAX_STORAGE_LENGTH)
+                {
+                    throw new InvalidOperationException(string.Format("Cannot set Storage to a string longer than {0} characters.", MAX_STORAGE_LENGTH));
+                }
+
+                this.m_storage = value ?? "";
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This PR modifies the Storage property so ingame scripts will throw an exception if they attempt to set it to a string longer than 8000 characters. This will reduce the amount of abuse that can be caused by ingame scripts such as bloating a game's RAM usage and the world save file.
