### PR TITLE
I my thrust max effective thrust

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyThrust.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyThrust.cs
@@ -18,6 +18,11 @@ namespace Sandbox.ModAPI.Ingame
         float MaxThrust { get; }
 
         /// <summary>
+        /// Gets the maximum effective thrust amount, in Newtons (N)
+        /// </summary>
+        float MaxEffectiveThrust { get; }
+
+        /// <summary>
         /// Gets the current thrust amount, in Newtons (N)
         /// </summary>
         float CurrentThrust { get; }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyThrust.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyThrust.cs
@@ -695,6 +695,14 @@ namespace Sandbox.Game.Entities
             }
         }
 
+        float Sandbox.ModAPI.Ingame.IMyThrust.MaxEffectiveThrust
+        {
+            get
+            {
+                return BlockDefinition.ForceMagnitude * m_thrustMultiplier * m_thrustComponent.GetLastThrustMultiplier(this);
+            }
+        }
+
         float Sandbox.ModAPI.Ingame.IMyThrust.CurrentThrust
         {
             get


### PR DESCRIPTION
This is to allow scripters to know the max possible thrust of a engine inside planetary influence and atmospheric influence.

If scripters want to get effective multiplier, user can do MaxEffectiveThrust/MaxThrust