### PR TITLE
Fixed the wheel offset (extend the suspension)

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyMotorSuspension.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyMotorSuspension.cs
@@ -686,8 +686,8 @@ namespace Sandbox.Game.Entities.Cube
             data.SetSuspensionDamping(m_damping);
             data.SetSuspensionStrength(m_strenth);
             //Min/MaxHeight also define the limits of the suspension and SuspensionTravel lowers this limit
-            data.SetSuspensionMinLimit((BlockDefinition.MinHeight - m_height)*SuspensionTravel);
-            data.SetSuspensionMaxLimit((BlockDefinition.MaxHeight - m_height)*SuspensionTravel);
+            data.SetSuspensionMinLimit((BlockDefinition.MinHeight - m_height)*SuspensionTravel+m_height);
+            data.SetSuspensionMaxLimit((BlockDefinition.MaxHeight - m_height)*SuspensionTravel+m_height);
             m_constraint = new HkConstraint(rotorBody, CubeGrid.Physics.RigidBody, data);
 
             m_constraint.WantRuntime = true;

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyMotorSuspension.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyMotorSuspension.cs
@@ -485,9 +485,9 @@ namespace Sandbox.Game.Entities.Cube
             if (SafeConstraint != null)
             {
                 (m_constraint.ConstraintData as HkWheelConstraintData).SetSuspensionMinLimit(
-                    (BlockDefinition.MinHeight - m_height) * SuspensionTravel);
+                    (BlockDefinition.MinHeight - m_height) * SuspensionTravel + m_height);
                 (m_constraint.ConstraintData as HkWheelConstraintData).SetSuspensionMaxLimit(
-                    (BlockDefinition.MaxHeight - m_height) * SuspensionTravel);
+                    (BlockDefinition.MaxHeight - m_height) * SuspensionTravel + m_height);
             }
         }
 


### PR DESCRIPTION
Currently, when set the wheel suspension travel to 0 in game, the wheel while be fixed at the middle (bottom/ min limit) of suspension. also it may extend to the outside of suspension. I think this may help