### PR TITLE
Update MyEngineerToolBase.cs

### DIFF
--- a/Sources/Sandbox.Game/Game/Weapons/Guns/MyEngineerToolBase.cs
+++ b/Sources/Sandbox.Game/Game/Weapons/Guns/MyEngineerToolBase.cs
@@ -66,7 +66,7 @@ namespace Sandbox.Game.Weapons
 
         protected MyEntity3DSoundEmitter m_soundEmitter;
 
-        protected MyCharacter Owner;
+        public MyCharacter Owner { get; protected set; }
 
         protected MyToolBase m_gunBase;
         public MyToolBase GunBase  { get { return m_gunBase;}}


### PR DESCRIPTION
As the Owner is protected there is no chance to get the EntityId of the Attacker in a 'MyAPIGateway.Session.DamageSystem.RegisterBeforeDamageHandler', and therefor no chance to get the correct relation between the attacker and the damaged block. (IMyEngineerToolBase has also to be extended)