### PR TITLE
Sandbox.Game.MyInventory  IsConnected is not thread safe

### DIFF
--- a/Sources/Sandbox.Game/ModAPI/MyInventory_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/MyInventory_ModAPI.cs
@@ -100,14 +100,12 @@ namespace Sandbox.Game
             return false;
         }
 
-        List<IMyConveyorEndpoint> reachableVertices = new List<IMyConveyorEndpoint>();
-
         private bool IsConnected(MyInventory dstInventory)
         {
             var srcConveyor = (this.Owner as IMyConveyorEndpointBlock);
             if (srcConveyor != null)
             {
-                reachableVertices.Clear();
+                var reachableVertices = new List<IMyConveyorEndpoint>();
                 MyGridConveyorSystem.FindReachable(srcConveyor.ConveyorEndpoint, reachableVertices, (vertex) => vertex.CubeBlock != null);
                 foreach (var vertex in reachableVertices)
                 {


### PR DESCRIPTION
As the 'reachableVertices' list is declared as field the usage of this list inside IsConnected is not thread safe.
The list is only used inside the function and cleared before every usage, I suggest to use an local list instead.
