### PR TITLE
Make Owner of MyEngineerToolBase/IMyEngineerToolBase public

### DIFF
--- a/Sources/Sandbox.Game/Game/Entities/Interfaces/IMyEngineerToolBase.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Interfaces/IMyEngineerToolBase.cs
@@ -11,5 +11,6 @@ namespace Sandbox.ModAPI.Weapons
 {
     public interface IMyEngineerToolBase : IMyEntity, IMyHandheldGunObject<MyToolBase>
     {
+       IMyCharacter Owner { get; }
     }
 }

--- a/Sources/Sandbox.Game/Game/Weapons/Guns/MyEngineerToolBase.cs
+++ b/Sources/Sandbox.Game/Game/Weapons/Guns/MyEngineerToolBase.cs
@@ -28,7 +28,7 @@ using Sandbox.ModAPI.Weapons;
 
 namespace Sandbox.Game.Weapons
 {
-    public abstract class MyEngineerToolBase : MyEntity, IMyHandheldGunObject<MyToolBase>, IMyEngineerToolBase
+    public abstract partial class MyEngineerToolBase : MyEntity, IMyHandheldGunObject<MyToolBase>, IMyEngineerToolBase
     {
         public static float GLARE_SIZE = 0.068f;
         /// <summary>
@@ -66,7 +66,7 @@ namespace Sandbox.Game.Weapons
 
         protected MyEntity3DSoundEmitter m_soundEmitter;
 
-        protected MyCharacter Owner;
+        public MyCharacter Owner { get; protected set; }
 
         protected MyToolBase m_gunBase;
         public MyToolBase GunBase  { get { return m_gunBase;}}

--- a/Sources/Sandbox.Game/ModAPI/MyEngineerToolBase_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/MyEngineerToolBase_ModAPI.cs
@@ -1,0 +1,16 @@
+﻿using VRage.Game.ModAPI;
+using Sandbox.ModAPI.Weapons;
+
+namespace Sandbox.Game.Weapons
+{
+    public abstract partial class MyEngineerToolBase : IMyEngineerToolBase
+    {
+      IMyCharacter IMyEngineerToolBase.Owner
+      {
+         get
+         {
+            return Owner;
+         }
+      }
+   }
+}

--- a/Sources/Sandbox.Game/ModAPI/MyInventory_ModAPI.cs
+++ b/Sources/Sandbox.Game/ModAPI/MyInventory_ModAPI.cs
@@ -100,14 +100,12 @@ namespace Sandbox.Game
             return false;
         }
 
-        List<IMyConveyorEndpoint> reachableVertices = new List<IMyConveyorEndpoint>();
-
         private bool IsConnected(MyInventory dstInventory)
         {
             var srcConveyor = (this.Owner as IMyConveyorEndpointBlock);
             if (srcConveyor != null)
             {
-                reachableVertices.Clear();
+                var reachableVertices = new List<IMyConveyorEndpoint>();
                 MyGridConveyorSystem.FindReachable(srcConveyor.ConveyorEndpoint, reachableVertices, (vertex) => vertex.CubeBlock != null);
                 foreach (var vertex in reachableVertices)
                 {


### PR DESCRIPTION
Currently grinder and welder reporting there EntiyId as attackerId to "DoDamage".
But as the MyEngineerToolBase currently not publish the Owner, there is no chance getting the current Owner (Character) of a grinder/welder.
So for e.g. there is no way to get the relation (GetUserRelationToOwner) inside of a MyAPIGateway.Session.DamageSystem.RegisterBeforeDamageHandler.

