### PR TITLE
Adding allowMultiple to the descriptor attribute

### DIFF
--- a/Sources/Sandbox.Game/Game/World/MyScriptManager.cs
+++ b/Sources/Sandbox.Game/Game/World/MyScriptManager.cs
@@ -256,9 +256,9 @@ namespace Sandbox.Game.World
             foreach (var type in assembly.GetTypes())
             {
                 var descriptorArray = type.GetCustomAttributes(typeof(MyEntityComponentDescriptor), false);
-                if (descriptorArray != null && descriptorArray.Length > 0)
+                foreach (var descriptorAttribute in descriptorArray)
                 {
-                    var descriptor = (MyEntityComponentDescriptor)descriptorArray[0];
+                    var descriptor = (MyEntityComponentDescriptor)descriptorAttribute;
                     try
                     {
                         var component = (MyGameLogicComponent)Activator.CreateInstance(type);

--- a/Sources/VRage.Game/Components/MyEntityComponentBase.cs
+++ b/Sources/VRage.Game/Components/MyEntityComponentBase.cs
@@ -4,7 +4,7 @@ using VRage.ModAPI;
 
 namespace VRage.Game.Components
 {
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple=true)]
     public class MyEntityComponentDescriptor : System.Attribute
     {
         public Type EntityBuilderType;


### PR DESCRIPTION
A little quality of life change for modders to make our code a little cleaner. The allowMultiple=false restriction to the myEntityComponentDescriptor attribute meant we needed to build duplicate classes for each builder we wanted to add logic to, rather than adding the same logic to multiple builders.

See this mod for the motivating example. (Ignore the lack of nuance to it. I'm just referring to the duplicated classes)
https://steamcommunity.com/sharedfiles/filedetails/?id=2288648839

No functionality is lost or modified with this change. The code already retrieves the attribute as an array. The null check would require a bug in system.reflection to fail, so can probably be omitted too. Thanks for your time.