### PR TITLE
Use LinkedList instead of Queue to find System.dll.

### DIFF
--- a/Sources/VRage.Library/Compiler/IlChecker.cs
+++ b/Sources/VRage.Library/Compiler/IlChecker.cs
@@ -26,7 +26,7 @@ namespace VRage.Compiler
             AllowNamespaceOfTypeCommon(typeof(System.Collections.IEnumerator));
             AllowNamespaceOfTypeCommon(typeof(System.Collections.Generic.IEnumerable<>));
             AllowNamespaceOfTypeCommon(typeof(System.Collections.Generic.HashSet<>));
-            AllowNamespaceOfTypeCommon(typeof(System.Collections.Generic.Queue<>));
+            AllowNamespaceOfTypeCommon(typeof(System.Collections.Generic.LinkedList<>));
             AllowNamespaceOfTypeCommon(typeof(System.Collections.Generic.ListExtensions));
             AllowNamespaceOfTypeCommon(typeof(System.Linq.Enumerable));
             AllowNamespaceOfTypeCommon(typeof(System.Text.StringBuilder));

--- a/Sources/VRage.Scripting/MyScriptWhitelist.cs
+++ b/Sources/VRage.Scripting/MyScriptWhitelist.cs
@@ -53,7 +53,7 @@ namespace VRage.Scripting
                     typeof(System.Collections.IEnumerator),
                     typeof(System.Collections.Generic.IEnumerable<>),
                     typeof(System.Collections.Generic.HashSet<>),
-                    typeof(System.Collections.Generic.Queue<>),
+                    typeof(System.Collections.Generic.LinkedList<>),
                     typeof(System.Collections.Concurrent.ConcurrentDictionary<,>),
                     typeof(System.Collections.Concurrent.ConcurrentBag<>),
                     typeof(System.Linq.Enumerable),


### PR DESCRIPTION
This should fix an incompatibility with Mono which is currently where the game fails in Proton without .NET Framework installed.

The problem with Mono is that they put System.Collections.Generic.Queue<> in mscorlib instead of System where MSDN says it's supposed to be: https://github.com/mono/mono/commit/df6056cd63d41cb7942dce69ebf50c6178d30602

This causes an exception when trying to add the namespace from the Queue class:
```
[000000000000010c:] EXCEPTION handling: VRage.Scripting.MyWhitelistException: Duplicate registration of the whitelist key System.Collections.Generic.*, mscorlib retrieved from System.Collections.Generic.IEnumerator`1[T]
```

Mono is clearly at fault here, but it's proving to be difficult to fix in wine-mono, not because of the code dependencies in Mono (there's only one and it can be easily replaced with List), but because of the bootstrapping process. Moving the type out of mscorlib breaks the monolite binaries which means we need to generate new ones that work without going through the normal build process somehow, and then develop a process to ship them instead of relying on upstream Mono.

I think if you instead reference a class that Mono put in the right place, that should work around this particular issue. Would you be willing to do that?